### PR TITLE
Reducing .NET Core dependencies - Depending on NETStandard.Library 1.6

### DIFF
--- a/Enyim.Caching/project.json
+++ b/Enyim.Caching/project.json
@@ -1,34 +1,27 @@
 {
-  "version": "1.0.0.4",
-  "name": "EnyimMemcachedCore",
-  "description": "EnyimMemcachedCore is .NET Core client library for memcached. Usage: services.AddEnyimMemcached(options => options.AddServer(serverNameOrIP, 11211)); Then add IMemcachedClient into constructor.",
-  "packOptions": {
-    "repository": {
-      "type": "git",
-      "url": "https://github.com/cnblogs/EnyimMemcachedCore"
+    "version": "1.0.0.4",
+    "name": "EnyimMemcachedCore",
+    "description": "EnyimMemcachedCore is .NET Core client library for memcached. Usage: services.AddEnyimMemcached(options => options.AddServer(serverNameOrIP, 11211)); Then add IMemcachedClient into constructor.",
+    "packOptions": {
+        "repository": {
+            "type": "git",
+            "url": "https://github.com/cnblogs/EnyimMemcachedCore"
+        },
+        "tags": [ "memcached", "cache" ]
     },
-    "tags": [ "memcached", "cache" ]
-  },
-  "configurations": {
-    "Debug": {
-      "buildOptions": {
+    "buildOptions": {
         "allowUnsafe": true
-      }
     },
-    "Release": {
-      "buildOptions": {
-        "allowUnsafe": true
-      }
+    "frameworks": {
+        "netstandard1.3": {}
+    },
+    "dependencies": {
+        "NETStandard.Library": "1.6.0",
+        "System.Net.NameResolution": "4.0.0",
+        "System.Threading.Thread": "4.0.0" ,
+        "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
+        "Newtonsoft.Json": "9.0.1",
+        "Microsoft.Extensions.Options": "1.0.0",
+        "Microsoft.Extensions.Caching.Abstractions": "1.0.0"
     }
-  },
-  "frameworks": {
-    "netcoreapp1.0.1": {}
-  },
-  "dependencies": {
-    "Microsoft.NETCore.App": "1.0.1",
-    "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
-    "Newtonsoft.Json": "9.0.1",
-    "Microsoft.Extensions.Options": "1.0.0",
-    "Microsoft.Extensions.Caching.Abstractions": "1.0.0"
-  }
 }

--- a/Enyim.Caching/project.json
+++ b/Enyim.Caching/project.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0.4",
+    "version": "1.0.0.5",
     "name": "EnyimMemcachedCore",
     "description": "EnyimMemcachedCore is .NET Core client library for memcached. Usage: services.AddEnyimMemcached(options => options.AddServer(serverNameOrIP, 11211)); Then add IMemcachedClient into constructor.",
     "packOptions": {


### PR DESCRIPTION
...with extension packages for DNS and Threads.

In order to create dependencies to this lib from other libs, which require more basic dependencies to .NET Core, it's necessary to reduce the framework dependency of EnyimMemcachedCore.

See also this recommendation: https://github.com/dotnet/core-docs/blob/master/docs/core/tutorials/libraries.md#how-to-target-the-net-standard

> [...] Although there's nothing preventing you from depending on Microsoft.NETCore.App like with console apps, it's generally not recommended. If you need APIs from a package not specified in NETStandard.Library, you can always specify that package in addition to NETStandard.Library in the dependencies section of your project.json file.

I also bumped the version number to 1.0.0.5 already, it would be great if you could deploy new NuGet Packages soon, as we're in the phase of starting to use this fork productively.
