### PR TITLE
Fix deadlock when resolving host name to IP address

### DIFF
--- a/Enyim.Caching/Configuration/MemcachedClientConfiguration.cs
+++ b/Enyim.Caching/Configuration/MemcachedClientConfiguration.cs
@@ -38,18 +38,15 @@ namespace Enyim.Caching.Configuration
             Servers = new List<EndPoint>();
             foreach (var server in options.Servers)
             {
-                var methodInfo = $"Call ResolveToEndPoint(\"{server.Address}\", {server.Port})";
-                try
+                IPAddress address;
+                if (IPAddress.TryParse(server.Address, out address))
                 {
-                    _logger.LogDebug(methodInfo);
-                    var endpoint = ConfigurationHelper.ResolveToEndPoint(server.Address, server.Port);
-                    _logger.LogDebug($"Result of ResolveToEndPoint(): {endpoint}");
-                    Servers.Add(endpoint);
+                    Servers.Add(new IPEndPoint(address, server.Port));
                 }
-                catch (Exception ex)
+                else
                 {
-                    _logger.LogError(new EventId(), ex, methodInfo);
-                }
+                    Servers.Add(new DnsEndPoint(server.Address, server.Port));
+                }                
             }
             SocketPool = options.SocketPool;
             Protocol = options.Protocol;

--- a/Enyim.Caching/project.json
+++ b/Enyim.Caching/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0.2",
+  "version": "1.1.1.0",
   "name": "EnyimMemcachedCore",
   "description": "EnyimMemcachedCore is a Memcached client library for .NET Core. Usage: Add services.AddEnyimMemcached(...) and app.UseEnyimMemcached() in Startup. Add IMemcachedClient into constructor.",
   "projectUrl": "https://github.com/cnblogs/EnyimMemcachedCore",

--- a/SampleWebApp/project.json
+++ b/SampleWebApp/project.json
@@ -8,7 +8,7 @@
     "Microsoft.AspNetCore.Diagnostics": "1.1.0",
     "Microsoft.AspNetCore.Server.Kestrel": "1.1.0",
     "Microsoft.Extensions.Logging.Console": "1.1.0",
-    "EnyimMemcachedCore": "1.1.0.1",
+    "EnyimMemcachedCore": "1.1.1.0",
     "Microsoft.Extensions.Logging.Filter": "1.1.0",
     "Microsoft.Extensions.Configuration.Abstractions": "1.1.0",
     "Microsoft.Extensions.Configuration.FileExtensions": "1.1.0",


### PR DESCRIPTION
Address dotnet/coreclr#8383

The deadlock occurs when synchronously calling asynchronous method to reslove host name to IP address with concurrent requests are coming in.

To avoid this deadlock, resloving host name to IP should be synchronous. But there is not synchronous api for it in System.Net.Dns of System.Net.NameResolution 4.3.0.

A workaround is using DnsEndPoint. But it does not work on non-Windows platforms. Anohter workaround is using reflection to call private InternalGetHostByName() method of System.Net.Dns for non-Windows platforms. The pull request takes this approach.