### PR TITLE
Support TypeCode.DBNull in DefaultTranscoder

### DIFF
--- a/Enyim.Caching/Memcached/Transcoders/DefaultTranscoder.cs
+++ b/Enyim.Caching/Memcached/Transcoders/DefaultTranscoder.cs
@@ -66,13 +66,12 @@ namespace Enyim.Caching.Memcached
             }
 
             ArraySegment<byte> data;
-            TypeCode code = value.GetType().GetTypeCode();
-
-            //TypeCode code = value == null ? TypeCode.DBNull : Type.GetTypeCode(value.GetType());
+            // TypeCode.DBNull is 2
+            TypeCode code = value == null ? (TypeCode)2 : Type.GetTypeCode(value.GetType());
 
             switch (code)
             {
-                //case TypeCode.DBNull: data = this.SerializeNull(); break;
+                case (TypeCode)2: data = this.SerializeNull(); break; // TypeCode.DBNull
                 case TypeCode.String: data = this.SerializeString(value.ToString()); break;
                 case TypeCode.Boolean: data = this.SerializeBoolean((Boolean)value); break;
                 case TypeCode.SByte: data = this.SerializeSByte((SByte)value); break;
@@ -145,7 +144,7 @@ namespace Enyim.Caching.Memcached
                             ? null
                             : DeserializeString(data);
 
-                //case TypeCode.DBNull: return null;
+                case (TypeCode)2: return null; // TypeCode.DBNull
                 case TypeCode.String: return this.DeserializeString(data);
                 case TypeCode.Boolean: return this.DeserializeBoolean(data);
                 case TypeCode.Int16: return this.DeserializeInt16(data);


### PR DESCRIPTION
This will preserve the behavior of the original EnyimMemcaced
before it was ported to .NET Core