### PR TITLE
Add NodeLocatorFactory to configuration.

### DIFF
--- a/Enyim.Caching/Configuration/MemcachedClientConfiguration.cs
+++ b/Enyim.Caching/Configuration/MemcachedClientConfiguration.cs
@@ -100,6 +100,11 @@ namespace Enyim.Caching.Configuration
             {
                 _transcoder = options.Transcoder;
             }
+
+            if (options.NodeLocatorFactory != null)
+            {
+                NodeLocatorFactory = options.NodeLocatorFactory;
+            }
         }   
 
 		/// <summary>

--- a/Enyim.Caching/Configuration/MemcachedClientOptions.cs
+++ b/Enyim.Caching/Configuration/MemcachedClientOptions.cs
@@ -21,6 +21,8 @@ namespace Enyim.Caching.Configuration
 
         public ITranscoder Transcoder { get; set; }
 
+        public IProviderFactory<IMemcachedNodeLocator> NodeLocatorFactory { get; set; }
+
         public MemcachedClientOptions Value => this;
 
         public void AddServer(string address, int port)


### PR DESCRIPTION
I didn't see a more readily available way to set a custom NodeLocatorFactory (and thereby NodeLocator), and thought using MemcachedClientOptions and MemcachedClientConfiguration looked like the most appropriate place. 