### PR TITLE
Simplify the usages of Transcoder and KeyTransformer.

### DIFF
--- a/Enyim.Caching/Configuration/MemcachedClientConfiguration.cs
+++ b/Enyim.Caching/Configuration/MemcachedClientConfiguration.cs
@@ -106,10 +106,21 @@ namespace Enyim.Caching.Configuration
                 }
             }
 
-            if (keyTransformer != null)
+            if (!string.IsNullOrEmpty(options.KeyTransformer))
             {
-                this._keyTransformer = keyTransformer;
-                _logger.LogDebug($"Use KeyTransformer Type : '{keyTransformer.ToString()}'");
+                try
+                {
+                    var keyTransformerType = Type.GetType(options.KeyTransformer);
+                    if (keyTransformerType != null)
+                    {
+                        KeyTransformer = Activator.CreateInstance(keyTransformerType) as IMemcachedKeyTransformer;
+                        _logger.LogDebug($"Use '{options.KeyTransformer}' KeyTransformer");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(new EventId(), ex, $"Unable to load '{options.KeyTransformer}' KeyTransformer");
+                }
             }
 
             if (NodeLocator == null)

--- a/Enyim.Caching/Configuration/MemcachedClientConfiguration.cs
+++ b/Enyim.Caching/Configuration/MemcachedClientConfiguration.cs
@@ -122,6 +122,11 @@ namespace Enyim.Caching.Configuration
                     _logger.LogError(new EventId(), ex, $"Unable to load '{options.KeyTransformer}' KeyTransformer");
                 }
             }
+            else if (keyTransformer != null)
+            {
+                this._keyTransformer = keyTransformer;
+                _logger.LogDebug($"Use KeyTransformer Type : '{keyTransformer.ToString()}'");
+            }
 
             if (NodeLocator == null)
             {

--- a/Enyim.Caching/Configuration/MemcachedClientConfiguration.cs
+++ b/Enyim.Caching/Configuration/MemcachedClientConfiguration.cs
@@ -17,7 +17,7 @@ namespace Enyim.Caching.Configuration
         // these are lazy initialized in the getters
         private Type nodeLocator;
         private ITranscoder _transcoder;
-        private IMemcachedKeyTransformer keyTransformer;
+        private IMemcachedKeyTransformer _keyTransformer;
         private ILogger<MemcachedClientConfiguration> _logger;
 
         /// <summary>
@@ -25,7 +25,9 @@ namespace Enyim.Caching.Configuration
         /// </summary>
         public MemcachedClientConfiguration(
             ILoggerFactory loggerFactory,
-            IOptions<MemcachedClientOptions> optionsAccessor)
+            IOptions<MemcachedClientOptions> optionsAccessor,
+            ITranscoder transcoder = null,
+            IMemcachedKeyTransformer keyTransformer = null)
         {
             if (optionsAccessor == null)
             {
@@ -46,7 +48,7 @@ namespace Enyim.Caching.Configuration
                 else
                 {
                     Servers.Add(new DnsEndPoint(server.Address, server.Port));
-                }                
+                }
             }
 
             SocketPool = new SocketPoolConfiguration();
@@ -61,8 +63,8 @@ namespace Enyim.Caching.Configuration
                 SocketPool.MaxPoolSize = options.SocketPool.MaxPoolSize;
                 _logger.LogInformation($"{nameof(SocketPool.MaxPoolSize)}: {SocketPool.MaxPoolSize}");
 
-                SocketPool.ConnectionTimeout = options.SocketPool.ConnectionTimeout;                
-                _logger.LogInformation($"{nameof(SocketPool.ConnectionTimeout)}: {SocketPool.ConnectionTimeout}");                              
+                SocketPool.ConnectionTimeout = options.SocketPool.ConnectionTimeout;
+                _logger.LogInformation($"{nameof(SocketPool.ConnectionTimeout)}: {SocketPool.ConnectionTimeout}");
 
                 SocketPool.ReceiveTimeout = options.SocketPool.ReceiveTimeout;
                 _logger.LogInformation($"{nameof(SocketPool.ReceiveTimeout)}: {SocketPool.ReceiveTimeout}");
@@ -104,181 +106,156 @@ namespace Enyim.Caching.Configuration
                 }
             }
 
-            if(!string.IsNullOrEmpty(options.KeyTransformer))
+            if (keyTransformer != null)
             {
-                try
-                {
-                    var keyTransformerType = Type.GetType(options.KeyTransformer);
-                    if (keyTransformerType != null)
-                    {
-                        KeyTransformer = Activator.CreateInstance(keyTransformerType) as IMemcachedKeyTransformer;
-                        _logger.LogDebug($"Use '{options.KeyTransformer}' KeyTransformer");
-                    }
-                }
-                catch(Exception ex)
-                {
-                    _logger.LogError(new EventId(), ex, $"Unable to load '{options.KeyTransformer}' KeyTransformer");
-                }                
+                this._keyTransformer = keyTransformer;
+                _logger.LogDebug($"Use KeyTransformer Type : '{keyTransformer.ToString()}'");
             }
 
-            if(NodeLocator == null)
+            if (NodeLocator == null)
             {
                 NodeLocator = options.Servers.Count > 1 ? typeof(DefaultNodeLocator) : typeof(SingleNodeLocator);
             }
 
-            if(!string.IsNullOrEmpty(options.Transcoder))
+            if (transcoder != null)
             {
-                try
-                {
-                    if (options.Transcoder == "BinaryFormatterTranscoder")
-                        options.Transcoder = "Enyim.Caching.Memcached.Transcoders.BinaryFormatterTranscoder";
-
-                    var transcoderType = Type.GetType(options.Transcoder);
-                    if (transcoderType != null)
-                    {
-                        Transcoder = Activator.CreateInstance(transcoderType) as ITranscoder;
-                        _logger.LogDebug($"Use '{options.Transcoder}'");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(new EventId(), ex, $"Unable to load '{options.Transcoder}'");
-                }
+                this._transcoder = transcoder;
+                _logger.LogDebug($"Use Transcoder Type : '{transcoder.ToString()}'");
             }
 
             if (options.NodeLocatorFactory != null)
             {
                 NodeLocatorFactory = options.NodeLocatorFactory;
             }
-        }   
+        }
 
-		/// <summary>
-		/// Adds a new server to the pool.
-		/// </summary>
-		/// <param name="address">The address and the port of the server in the format 'host:port'.</param>
-		public void AddServer(string address)
-		{
-			this.Servers.Add(ConfigurationHelper.ResolveToEndPoint(address));
-		}
+        /// <summary>
+        /// Adds a new server to the pool.
+        /// </summary>
+        /// <param name="address">The address and the port of the server in the format 'host:port'.</param>
+        public void AddServer(string address)
+        {
+            this.Servers.Add(ConfigurationHelper.ResolveToEndPoint(address));
+        }
 
-		/// <summary>
-		/// Adds a new server to the pool.
-		/// </summary>
-		/// <param name="address">The host name or IP address of the server.</param>
-		/// <param name="port">The port number of the memcached instance.</param>
-		public void AddServer(string host, int port)
-		{
-			this.Servers.Add(ConfigurationHelper.ResolveToEndPoint(host, port));
-		}
+        /// <summary>
+        /// Adds a new server to the pool.
+        /// </summary>
+        /// <param name="address">The host name or IP address of the server.</param>
+        /// <param name="port">The port number of the memcached instance.</param>
+        public void AddServer(string host, int port)
+        {
+            this.Servers.Add(ConfigurationHelper.ResolveToEndPoint(host, port));
+        }
 
-		/// <summary>
-		/// Gets a list of <see cref="T:IPEndPoint"/> each representing a Memcached server in the pool.
-		/// </summary>
-		public IList<EndPoint> Servers { get; private set; }
+        /// <summary>
+        /// Gets a list of <see cref="T:IPEndPoint"/> each representing a Memcached server in the pool.
+        /// </summary>
+        public IList<EndPoint> Servers { get; private set; }
 
-		/// <summary>
-		/// Gets the configuration of the socket pool.
-		/// </summary>
-		public ISocketPoolConfiguration SocketPool { get; private set; }
+        /// <summary>
+        /// Gets the configuration of the socket pool.
+        /// </summary>
+        public ISocketPoolConfiguration SocketPool { get; private set; }
 
-		/// <summary>
-		/// Gets the authentication settings.
-		/// </summary>
-		public IAuthenticationConfiguration Authentication { get; private set; }
+        /// <summary>
+        /// Gets the authentication settings.
+        /// </summary>
+        public IAuthenticationConfiguration Authentication { get; private set; }
 
-		/// <summary>
-		/// Gets or sets the <see cref="T:Enyim.Caching.Memcached.IMemcachedKeyTransformer"/> which will be used to convert item keys for Memcached.
-		/// </summary>
-		public IMemcachedKeyTransformer KeyTransformer
-		{
-			get { return this.keyTransformer ?? (this.keyTransformer = new DefaultKeyTransformer()); }
-			set { this.keyTransformer = value; }
-		}
+        /// <summary>
+        /// Gets or sets the <see cref="T:Enyim.Caching.Memcached.IMemcachedKeyTransformer"/> which will be used to convert item keys for Memcached.
+        /// </summary>
+        public IMemcachedKeyTransformer KeyTransformer
+        {
+            get { return this._keyTransformer ?? (this._keyTransformer = new DefaultKeyTransformer()); }
+            set { this._keyTransformer = value; }
+        }
 
-		/// <summary>
-		/// Gets or sets the Type of the <see cref="T:Enyim.Caching.Memcached.IMemcachedNodeLocator"/> which will be used to assign items to Memcached nodes.
-		/// </summary>
-		/// <remarks>If both <see cref="M:NodeLocator"/> and  <see cref="M:NodeLocatorFactory"/> are assigned then the latter takes precedence.</remarks>
-		public Type NodeLocator
-		{
-			get { return this.nodeLocator; }
-			set
-			{
-				ConfigurationHelper.CheckForInterface(value, typeof(IMemcachedNodeLocator));
-				this.nodeLocator = value;
-			}
-		}
+        /// <summary>
+        /// Gets or sets the Type of the <see cref="T:Enyim.Caching.Memcached.IMemcachedNodeLocator"/> which will be used to assign items to Memcached nodes.
+        /// </summary>
+        /// <remarks>If both <see cref="M:NodeLocator"/> and  <see cref="M:NodeLocatorFactory"/> are assigned then the latter takes precedence.</remarks>
+        public Type NodeLocator
+        {
+            get { return this.nodeLocator; }
+            set
+            {
+                ConfigurationHelper.CheckForInterface(value, typeof(IMemcachedNodeLocator));
+                this.nodeLocator = value;
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the NodeLocatorFactory instance which will be used to create a new IMemcachedNodeLocator instances.
-		/// </summary>
-		/// <remarks>If both <see cref="M:NodeLocator"/> and  <see cref="M:NodeLocatorFactory"/> are assigned then the latter takes precedence.</remarks>
-		public IProviderFactory<IMemcachedNodeLocator> NodeLocatorFactory { get; set; }
+        /// <summary>
+        /// Gets or sets the NodeLocatorFactory instance which will be used to create a new IMemcachedNodeLocator instances.
+        /// </summary>
+        /// <remarks>If both <see cref="M:NodeLocator"/> and  <see cref="M:NodeLocatorFactory"/> are assigned then the latter takes precedence.</remarks>
+        public IProviderFactory<IMemcachedNodeLocator> NodeLocatorFactory { get; set; }
 
-		/// <summary>
-		/// Gets or sets the <see cref="T:Enyim.Caching.Memcached.ITranscoder"/> which will be used serialize or deserialize items.
-		/// </summary>
-		public ITranscoder Transcoder
-		{
-			get { return _transcoder ?? (_transcoder = new DefaultTranscoder()); }
-			set { _transcoder = value; }
-		}
+        /// <summary>
+        /// Gets or sets the <see cref="T:Enyim.Caching.Memcached.ITranscoder"/> which will be used serialize or deserialize items.
+        /// </summary>
+        public ITranscoder Transcoder
+        {
+            get { return _transcoder ?? (_transcoder = new DefaultTranscoder()); }
+            set { _transcoder = value; }
+        }
 
-		/// <summary>
-		/// Gets or sets the type of the communication between client and server.
-		/// </summary>
-		public MemcachedProtocol Protocol { get; set; }
+        /// <summary>
+        /// Gets or sets the type of the communication between client and server.
+        /// </summary>
+        public MemcachedProtocol Protocol { get; set; }
 
-		#region [ interface                     ]
+        #region [ interface                     ]
 
-		IList<System.Net.EndPoint> IMemcachedClientConfiguration.Servers
-		{
-			get { return this.Servers; }
-		}
+        IList<System.Net.EndPoint> IMemcachedClientConfiguration.Servers
+        {
+            get { return this.Servers; }
+        }
 
-		ISocketPoolConfiguration IMemcachedClientConfiguration.SocketPool
-		{
-			get { return this.SocketPool; }
-		}
+        ISocketPoolConfiguration IMemcachedClientConfiguration.SocketPool
+        {
+            get { return this.SocketPool; }
+        }
 
-		IAuthenticationConfiguration IMemcachedClientConfiguration.Authentication
-		{
-			get { return this.Authentication; }
-		} 
+        IAuthenticationConfiguration IMemcachedClientConfiguration.Authentication
+        {
+            get { return this.Authentication; }
+        }
 
         IMemcachedKeyTransformer IMemcachedClientConfiguration.CreateKeyTransformer()
-		{
-			return this.KeyTransformer;
-		}
+        {
+            return this.KeyTransformer;
+        }
 
-		IMemcachedNodeLocator IMemcachedClientConfiguration.CreateNodeLocator()
-		{
-			var f = this.NodeLocatorFactory;
-			if (f != null) return f.Create();
+        IMemcachedNodeLocator IMemcachedClientConfiguration.CreateNodeLocator()
+        {
+            var f = this.NodeLocatorFactory;
+            if (f != null) return f.Create();
 
-			return this.NodeLocator == null
-					? new SingleNodeLocator() 
+            return this.NodeLocator == null
+                    ? new SingleNodeLocator()
                     : (IMemcachedNodeLocator)FastActivator.Create(this.NodeLocator);
-		}
+        }
 
-		ITranscoder IMemcachedClientConfiguration.CreateTranscoder()
-		{
-			return this.Transcoder;
-		}
+        ITranscoder IMemcachedClientConfiguration.CreateTranscoder()
+        {
+            return this.Transcoder;
+        }
 
-		IServerPool IMemcachedClientConfiguration.CreatePool()
-		{
-			switch (this.Protocol)
-			{
-				case MemcachedProtocol.Text: return new DefaultServerPool(this, new Memcached.Protocol.Text.TextOperationFactory(), _logger);
-				case MemcachedProtocol.Binary: return new BinaryPool(this, _logger);
-			}
+        IServerPool IMemcachedClientConfiguration.CreatePool()
+        {
+            switch (this.Protocol)
+            {
+                case MemcachedProtocol.Text: return new DefaultServerPool(this, new Memcached.Protocol.Text.TextOperationFactory(), _logger);
+                case MemcachedProtocol.Binary: return new BinaryPool(this, _logger);
+            }
 
-			throw new ArgumentOutOfRangeException("Unknown protocol: " + (int)this.Protocol);
-		}		
+            throw new ArgumentOutOfRangeException("Unknown protocol: " + (int)this.Protocol);
+        }
 
-		#endregion
-	}
+        #endregion
+    }
 }
 
 #region [ License information          ]

--- a/Enyim.Caching/Configuration/MemcachedClientConfiguration.cs
+++ b/Enyim.Caching/Configuration/MemcachedClientConfiguration.cs
@@ -133,7 +133,26 @@ namespace Enyim.Caching.Configuration
                 NodeLocator = options.Servers.Count > 1 ? typeof(DefaultNodeLocator) : typeof(SingleNodeLocator);
             }
 
-            if (transcoder != null)
+            if (!string.IsNullOrEmpty(options.Transcoder))
+            {
+                try
+                {
+                    if (options.Transcoder == "BinaryFormatterTranscoder")
+                        options.Transcoder = "Enyim.Caching.Memcached.Transcoders.BinaryFormatterTranscoder";
+
+                    var transcoderType = Type.GetType(options.Transcoder);
+                    if (transcoderType != null)
+                    {
+                        Transcoder = Activator.CreateInstance(transcoderType) as ITranscoder;
+                        _logger.LogDebug($"Use '{options.Transcoder}'");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(new EventId(), ex, $"Unable to load '{options.Transcoder}'");
+                }
+            }
+            else if (transcoder != null)
             {
                 this._transcoder = transcoder;
                 _logger.LogDebug($"Use Transcoder Type : '{transcoder.ToString()}'");

--- a/Enyim.Caching/EnyimMemcachedServiceCollectionExtensions.cs
+++ b/Enyim.Caching/EnyimMemcachedServiceCollectionExtensions.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Extensions.DependencyInjection
             configure(services);
 
             services.TryAddSingleton<ITranscoder, DefaultTranscoder>();
+            services.TryAddSingleton<IMemcachedKeyTransformer, DefaultKeyTransformer>();
             services.TryAddTransient<IMemcachedClientConfiguration, MemcachedClientConfiguration>();
             services.AddSingleton<MemcachedClient, MemcachedClient>();
 

--- a/Enyim.Caching/EnyimMemcachedServiceCollectionExtensions.cs
+++ b/Enyim.Caching/EnyimMemcachedServiceCollectionExtensions.cs
@@ -47,7 +47,6 @@ namespace Microsoft.Extensions.DependencyInjection
             configure(services);
 
             services.TryAddSingleton<ITranscoder, DefaultTranscoder>();
-            services.TryAddSingleton<IMemcachedKeyTransformer, DefaultKeyTransformer>();
             services.TryAddTransient<IMemcachedClientConfiguration, MemcachedClientConfiguration>();
             services.AddSingleton<MemcachedClient, MemcachedClient>();
 

--- a/Enyim.Caching/EnyimMemcachedServiceCollectionExtensions.cs
+++ b/Enyim.Caching/EnyimMemcachedServiceCollectionExtensions.cs
@@ -1,12 +1,11 @@
 ﻿using Enyim.Caching;
 using Enyim.Caching.Configuration;
+using Enyim.Caching.Memcached;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -46,7 +45,10 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.AddOptions();
             configure(services);
-            services.AddTransient<IMemcachedClientConfiguration, MemcachedClientConfiguration>();
+
+            services.TryAddSingleton<ITranscoder, DefaultTranscoder>();
+            services.TryAddSingleton<IMemcachedKeyTransformer, DefaultKeyTransformer>();
+            services.TryAddTransient<IMemcachedClientConfiguration, MemcachedClientConfiguration>();
             services.AddSingleton<MemcachedClient, MemcachedClient>();
 
             services.AddSingleton<IMemcachedClient>(factory => factory.GetService<MemcachedClient>());

--- a/MemcachedTest/MemcachedClientTest.cs
+++ b/MemcachedTest/MemcachedClientTest.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Net;
-using System.Threading;
 using Enyim.Caching;
-using Enyim.Caching.Configuration;
 using Enyim.Caching.Memcached;
+using Enyim.Caching.Memcached.Transcoders;
 using System.Collections.Generic;
 using System.Text;
 using Xunit;
@@ -26,11 +24,16 @@ namespace MemcachedTest
             {
                 options.AddServer("memcached", 11211);
                 options.Protocol = protocol;
-                if (useBinaryFormatterTranscoder)
-                {
-                    options.Transcoder = "BinaryFormatterTranscoder";
-                }
+                //if (useBinaryFormatterTranscoder)
+                //{
+                //    options.Transcoder = "BinaryFormatterTranscoder";
+                //}
             });
+            if(useBinaryFormatterTranscoder)
+            {
+                services.AddSingleton<ITranscoder,BinaryFormatterTranscoder>();
+            }
+
             services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Error).AddConsole());
 
             IServiceProvider serviceProvider = services.BuildServiceProvider();


### PR DESCRIPTION
At current version of EnyimMemcachedCore, we need to specify the Type of KeyTransformer and  Transcoder by the following configuration or read from `appsettings.json`.

```csharp
services.AddEnyimMemcached(options =>
{
    options.AddServer("memcached", 11211);
    options.Protocol = protocol;
    options.Transcoder = "MyNamespace.TranscoderName,MyNamespace";
    options.KeyTransformer = "MyNamespace.KeyTransformerName,MyNamespace";
});
```

I think the following code may be more convenient and follow the style of .net core. 

```csharp
services.AddEnyimMemcached(options =>
{
    options.AddServer("memcached", 11211);
    options.Protocol = protocol;
});
services.AddSingleton<ITranscoder, TranscoderName>();
services.AddSingleton<IMemcachedKeyTransformer, KeyTransformerName>();
```

This also can reduce the probability of error when using `Activator.CreateInstance` to create an instance by wrong spelling of the types!

I also use this style in [EasyCaching](https://github.com/catcherwong/EasyCaching/blob/master/src/EasyCaching.Memcached/EasyCachingMemcachedClientConfiguration.cs) now!

