### PR TITLE
Make DefaultNodeLocator take the ServerAddressMutations as a parameter

### DIFF
--- a/Enyim.Caching/Memcached/Locators/Factories/DefaultNodeLocatorFactory.cs
+++ b/Enyim.Caching/Memcached/Locators/Factories/DefaultNodeLocatorFactory.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace Enyim.Caching.Memcached.LocatorFactories
+{
+    /// <summary>
+    /// Create DefaultNodeLocator with any ServerAddressMutations
+    /// </summary>
+    public class DefaultNodeLocatorFactory :IProviderFactory<IMemcachedNodeLocator>
+    {
+        private readonly int serverAddressMutations;
+
+        public DefaultNodeLocatorFactory(int serverAddressMutations)
+        {
+            this.serverAddressMutations = serverAddressMutations;
+        }
+
+        public IMemcachedNodeLocator Create()
+        {
+            return new DefaultNodeLocator(serverAddressMutations);
+        }
+
+        public void Initialize(Dictionary<string, string> parameters)
+        {
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a functionality to change the `ServerAddressMutations` value in the `DefaultNodeLocator` that control the count of virtual nodes.

In my case, my nodes are too few (only 2) and the count of virtual nodes is not enough to balancing.
I would like to set multiplier to 10000 so that prevent unbalancing.