### PR TITLE
Add Replace method, Add return values for Store wrappers

### DIFF
--- a/Enyim.Caching/IMemcachedClient.cs
+++ b/Enyim.Caching/IMemcachedClient.cs
@@ -8,11 +8,14 @@ namespace Enyim.Caching
 {
     public interface IMemcachedClient : IDisposable
     {
-        void Add(string key, object value, int cacheSeconds);
-        Task AddAsync(string key, object value, int cacheSeconds);
+        bool Add(string key, object value, int cacheSeconds);
+        Task<bool> AddAsync(string key, object value, int cacheSeconds);
 
-        void Set(string key, object value, int cacheSeconds);
-        Task SetAsync(string key, object value, int cacheSeconds);
+        bool Set(string key, object value, int cacheSeconds);
+        Task<bool> SetAsync(string key, object value, int cacheSeconds);
+        
+        bool Replace(string key, object value, int cacheSeconds);
+        Task<bool> ReplaceAsync(string key, object value, int cacheSeconds);
 
         Task<IGetOperationResult<T>> GetAsync<T>(string key);
         Task<T> GetValueAsync<T>(string key);

--- a/Enyim.Caching/MemcachedClient.cs
+++ b/Enyim.Caching/MemcachedClient.cs
@@ -88,24 +88,34 @@ namespace Enyim.Caching
 
         public event Action<IMemcachedNode> NodeFailed;
 
-        public void Add(string key, object value, int cacheSeconds)
+        public bool Add(string key, object value, int cacheSeconds)
         {
-            Store(StoreMode.Add, key, value, TimeSpan.FromSeconds(cacheSeconds));
+            return Store(StoreMode.Add, key, value, TimeSpan.FromSeconds(cacheSeconds));
         }
 
-        public async Task AddAsync(string key, object value, int cacheSeconds)
+        public async Task<bool> AddAsync(string key, object value, int cacheSeconds)
         {
-            await StoreAsync(StoreMode.Add, key, value, TimeSpan.FromSeconds(cacheSeconds));
+            return await StoreAsync(StoreMode.Add, key, value, TimeSpan.FromSeconds(cacheSeconds));
         }
 
-        public void Set(string key, object value, int cacheSeconds)
+        public bool Set(string key, object value, int cacheSeconds)
         {
-            Store(StoreMode.Set, key, value, TimeSpan.FromSeconds(cacheSeconds));
+            return Store(StoreMode.Set, key, value, TimeSpan.FromSeconds(cacheSeconds));
         }
 
-        public async Task SetAsync(string key, object value, int cacheSeconds)
+        public async Task<bool> SetAsync(string key, object value, int cacheSeconds)
         {
-            await StoreAsync(StoreMode.Set, key, value, TimeSpan.FromSeconds(cacheSeconds));
+            return await StoreAsync(StoreMode.Set, key, value, TimeSpan.FromSeconds(cacheSeconds));
+        }
+
+        public bool Replace(string key, object value, int cacheSeconds)
+        {
+            return Store(StoreMode.Replace, key, value, TimeSpan.FromSeconds(cacheSeconds));
+        }
+
+        public async Task<bool> ReplaceAsync(string key, object value, int cacheSeconds)
+        {
+            return await StoreAsync(StoreMode.Replace, key, value, TimeSpan.FromSeconds(cacheSeconds));
         }
 
         /// <summary>

--- a/Enyim.Caching/NullMemcachedClient.cs
+++ b/Enyim.Caching/NullMemcachedClient.cs
@@ -234,23 +234,34 @@ namespace Enyim.Caching
             return false;
         }
 
-        public void Add(string key, object value, int cacheSeconds)
+        public bool Add(string key, object value, int cacheSeconds)
         {
+            return true;
         }
 
-        public Task AddAsync(string key, object value, int cacheSeconds)
+        public Task<bool> AddAsync(string key, object value, int cacheSeconds)
         {
-            return Task.CompletedTask;
+            return Task.FromResult(true);
         }
 
-        public void Set(string key, object value, int cacheSeconds)
+        public bool Set(string key, object value, int cacheSeconds)
         {
-
+            return true;
         }
 
-        public Task SetAsync(string key, object value, int cacheSeconds)
+        public Task<bool> SetAsync(string key, object value, int cacheSeconds)
         {
-            return Task.CompletedTask;
+            return Task.FromResult(true);
+        }
+        
+        public bool Replace(string key, object value, int cacheSeconds)
+        {
+            return true;
+        }
+
+        public Task<bool> ReplaceAsync(string key, object value, int cacheSeconds)
+        {
+            return Task.FromResult(true);
         }
 
         public Task<T> GetValueOrCreateAsync<T>(string key, int cacheSeconds, Func<Task<T>> generator)


### PR DESCRIPTION
This PR changes below:

- There are Set and Add wrapper methods but only Replace does not exist. -> add `Replace`, `ReplaceAsync`
- Each wrappers of Store method has no return value but Store does. -> add bool return values

This is a breaking change for IMemcachedClient.
I guess this changes affect a few users who has alternative implementations of IMemcachedClient.