### PR TITLE
Fix GetValueAsync concurrent issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ packages/*/
 project.lock.json
 /publish/*.bat
 .vs/
+.idea

--- a/Enyim.Caching/Enyim.Caching.csproj
+++ b/Enyim.Caching/Enyim.Caching.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>EnyimMemcachedCore is a Memcached client library for .NET Core. Usage: Add services.AddEnyimMemcached(...) and app.UseEnyimMemcached() in Startup. Add IMemcachedClient into constructor.</Description>
-    <VersionPrefix>2.2.0-beta1</VersionPrefix>
+    <VersionPrefix>2.1.14</VersionPrefix>
     <Authors>cnblogs.com</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Enyim.Caching/FastActivator.cs
+++ b/Enyim.Caching/FastActivator.cs
@@ -9,48 +9,54 @@ using System.Linq.Expressions;
 
 namespace Enyim.Reflection
 {
-	/// <summary>
-	/// <para>Implements a very fast object factory for dynamic object creation. Dynamically generates a factory class which will use the new() constructor of the requested type.</para>
-	/// <para>Much faster than using Activator at the price of the first invocation being significantly slower than subsequent calls.</para>
-	/// </summary>
-	public static class FastActivator
-	{
-		private static Dictionary<Type, Func<object>> factoryCache = new Dictionary<Type, Func<object>>();
+    /// <summary>
+    /// <para>Implements a very fast object factory for dynamic object creation. Dynamically generates a factory class which will use the new() constructor of the requested type.</para>
+    /// <para>Much faster than using Activator at the price of the first invocation being significantly slower than subsequent calls.</para>
+    /// </summary>
+    public static class FastActivator
+    {
+        private static Dictionary<Type, Func<object>> factoryCache = new Dictionary<Type, Func<object>>();
 
-		/// <summary>
-		/// Creates an instance of the specified type using a generated factory to avoid using Reflection.
-		/// </summary>
-		/// <typeparam name="T">The type to be created.</typeparam>
-		/// <returns>The newly created instance.</returns>
-		public static T Create<T>()
-		{
-			return TypeFactory<T>.Create();
-		}
+        /// <summary>
+        /// Creates an instance of the specified type using a generated factory to avoid using Reflection.
+        /// </summary>
+        /// <typeparam name="T">The type to be created.</typeparam>
+        /// <returns>The newly created instance.</returns>
+        public static T Create<T>()
+        {
+            return TypeFactory<T>.Create();
+        }
 
-		/// <summary>
-		/// Creates an instance of the specified type using a generated factory to avoid using Reflection.
-		/// </summary>
-		/// <param name="type">The type to be created.</param>
-		/// <returns>The newly created instance.</returns>
-		public static object Create(Type type)
-		{
-			Func<object> f;
+        /// <summary>
+        /// Creates an instance of the specified type using a generated factory to avoid using Reflection.
+        /// </summary>
+        /// <param name="type">The type to be created.</param>
+        /// <returns>The newly created instance.</returns>
+        public static object Create(Type type)
+        {
+            Func<object> f;
 
-			if (!factoryCache.TryGetValue(type, out f))
-				lock (factoryCache)
-					if (!factoryCache.TryGetValue(type, out f))
-					{
-						factoryCache[type] = f = Expression.Lambda<Func<object>>(Expression.New(type)).Compile();
-					}
+            if (!factoryCache.TryGetValue(type, out f))
+            {
+                lock (factoryCache)
+                    if (!factoryCache.TryGetValue(type, out f))
+                    {
+                        f = Expression.Lambda<Func<object>>(Expression.New(type)).Compile();
+                        if (f != null)
+                        {
+                            factoryCache[type] = f;
+                        }
+                    }
+            }
 
-			return f();
-		}
+            return f();
+        }
 
-		private static class TypeFactory<T>
-		{
-			public static readonly Func<T> Create = Expression.Lambda<Func<T>>(Expression.New(typeof(T))).Compile();
-		}
-	}
+        private static class TypeFactory<T>
+        {
+            public static readonly Func<T> Create = Expression.Lambda<Func<T>>(Expression.New(typeof(T))).Compile();
+        }
+    }
 }
 
 #region [ License information          ]

--- a/Enyim.Caching/Memcached/AsyncSocketHelper.cs
+++ b/Enyim.Caching/Memcached/AsyncSocketHelper.cs
@@ -269,12 +269,12 @@ namespace Enyim.Caching.Memcached
                 {
                     this.readInProgressEvent.Reset();
 
-                    if (this.socket.socket.ReceiveAsync(this.readEvent))
+                    if (this.socket._socket.ReceiveAsync(this.readEvent))
                     {
                         // wait until the timeout elapses, then abort this reading process
                         // EndREceive will be triggered sooner or later but its timeout
                         // may be higher than our read timeout, so it's not reliable
-                        if (!readInProgressEvent.WaitOne(this.socket.socket.ReceiveTimeout))
+                        if (!readInProgressEvent.WaitOne(this.socket._socket.ReceiveTimeout))
                             this.AbortReadAndTryPublishError(false);
 
                         return;
@@ -293,7 +293,7 @@ namespace Enyim.Caching.Memcached
             private void AbortReadAndTryPublishError(bool markAsDead)
             {
                 if (markAsDead)
-                    this.socket.isAlive = false;
+                    this.socket._isAlive = false;
 
                 // we've been already aborted, so quit
                 // both the EndReceive and the wait on the event can abort the read

--- a/Enyim.Caching/Memcached/MemcachedNode.cs
+++ b/Enyim.Caching/Memcached/MemcachedNode.cs
@@ -120,7 +120,7 @@ namespace Enyim.Caching.Memcached
             //could not reconnect
             catch { return false; }
         }
-        
+
         /// <summary>
         /// Acquires a new item from the pool
         /// </summary>
@@ -275,7 +275,7 @@ namespace Enyim.Caching.Memcached
                 _logger = logger;
                 _isDebugEnabled = _logger.IsEnabled(LogLevel.Debug);
             }
-            
+
             internal void InitPool()
             {
                 try
@@ -321,7 +321,7 @@ namespace Enyim.Caching.Memcached
                     }
 
                     if (_logger.IsEnabled(LogLevel.Debug))
-                        _logger.LogDebug("Pool has been inited for {0} with {1} sockets", this.endPoint, this.minItems);
+                        _logger.LogDebug("Pool has been inited for {0} with {1} sockets", _endPoint, this.minItems);
 
                 }
                 catch (Exception e)
@@ -356,7 +356,7 @@ namespace Enyim.Caching.Memcached
             {
                 get { return this.markedAsDeadUtc; }
             }
-            
+
             /// <summary>
             /// Acquires a new item from the pool
             /// </summary>
@@ -473,11 +473,11 @@ namespace Enyim.Caching.Memcached
                 var result = new PooledSocketResult();
                 var message = string.Empty;
 
-                if (_isDebugEnabled) _logger.LogDebug("Acquiring stream from pool. " + this.endPoint);
+                if (_isDebugEnabled) _logger.LogDebug("Acquiring stream from pool. " + _endPoint);
 
                 if (!this.isAlive || this.isDisposed)
                 {
-                    message = "Pool is dead or disposed, returning null. " + this.endPoint;
+                    message = "Pool is dead or disposed, returning null. " + _endPoint;
                     result.Fail(message);
 
                     if (_isDebugEnabled) _logger.LogDebug(message);
@@ -489,7 +489,7 @@ namespace Enyim.Caching.Memcached
 
                 if (!await this.semaphore.WaitAsync(this.queueTimeout))
                 {
-                    message = "Pool is full, timeouting. " + this.endPoint;
+                    message = "Pool is full, timeouting. " + _endPoint;
                     if (_isDebugEnabled) _logger.LogDebug(message);
                     result.Fail(message, new TimeoutException());
 
@@ -500,7 +500,7 @@ namespace Enyim.Caching.Memcached
                 // maybe we died while waiting
                 if (!this.isAlive)
                 {
-                    message = "Pool is dead, returning null. " + this.endPoint;
+                    message = "Pool is dead, returning null. " + _endPoint;
                     if (_isDebugEnabled) _logger.LogDebug(message);
                     result.Fail(message);
 
@@ -537,7 +537,7 @@ namespace Enyim.Caching.Memcached
                 }
 
                 // free item pool is empty
-                message = "Could not get a socket from the pool, Creating a new item. " + this.endPoint;
+                message = "Could not get a socket from the pool, Creating a new item. " + _endPoint;
                 if (_isDebugEnabled) _logger.LogDebug(message);
 
 
@@ -552,7 +552,7 @@ namespace Enyim.Caching.Memcached
                 }
                 catch (Exception e)
                 {
-                    message = "Failed to create socket. " + this.endPoint;
+                    message = "Failed to create socket. " + _endPoint;
                     _logger.LogError(message, e);
 
                     // eventhough this item failed the failure policy may keep the pool alive
@@ -702,7 +702,7 @@ namespace Enyim.Caching.Memcached
             try
             {
                 var ps = new PooledSocket(this.endPoint, this.config.ConnectionTimeout, this.config.ReceiveTimeout, _logger);
-                ps.Connect();
+                //ps.Connect();
                 return ps;
             }
             catch (Exception ex)
@@ -710,14 +710,14 @@ namespace Enyim.Caching.Memcached
                 _logger.LogError(ex, $"Create {nameof(PooledSocket)}");
                 throw;
             }
-            
+
         }
         protected internal virtual async Task<PooledSocket> CreateSocketAsync()
         {
             try
             {
                 var ps = new PooledSocket(this.endPoint, this.config.ConnectionTimeout, this.config.ReceiveTimeout, _logger);
-                await ps.ConnectAsync();
+                //await ps.ConnectAsync();
                 return ps;
             }
             catch (Exception ex)

--- a/Enyim.Caching/Memcached/MemcachedNode.cs
+++ b/Enyim.Caching/Memcached/MemcachedNode.cs
@@ -136,9 +136,9 @@ namespace Enyim.Caching.Memcached
                     this.internalPoolImpl.InitPool();
                     this.isInitialized = true;
                     _logger.LogInformation("MemcachedInitPool-cost: {0}ms", (DateTime.Now - startTime).TotalMilliseconds);
-                    poolInitSemaphore.Release();
                 }
             }
+
             try
             {
                 return this.internalPoolImpl.Acquire();
@@ -150,6 +150,10 @@ namespace Enyim.Caching.Memcached
                 var result = new PooledSocketResult();
                 result.Fail(message, e);
                 return result;
+            }
+            finally
+            {
+                poolInitSemaphore.Release();
             }
         }
 
@@ -210,6 +214,7 @@ namespace Enyim.Caching.Memcached
 
                 this.isDisposed = true;
                 this.internalPoolImpl.Dispose();
+                this.poolInitSemaphore.Dispose();
             }
         }
 

--- a/Enyim.Caching/Memcached/MemcachedNode.cs
+++ b/Enyim.Caching/Memcached/MemcachedNode.cs
@@ -702,7 +702,7 @@ namespace Enyim.Caching.Memcached
             try
             {
                 var ps = new PooledSocket(this.endPoint, this.config.ConnectionTimeout, this.config.ReceiveTimeout, _logger);
-                //ps.Connect();
+                ps.Connect();
                 return ps;
             }
             catch (Exception ex)
@@ -717,7 +717,7 @@ namespace Enyim.Caching.Memcached
             try
             {
                 var ps = new PooledSocket(this.endPoint, this.config.ConnectionTimeout, this.config.ReceiveTimeout, _logger);
-                //await ps.ConnectAsync();
+                await ps.ConnectAsync();
                 return ps;
             }
             catch (Exception ex)

--- a/Enyim.Caching/Memcached/MemcachedNode.cs
+++ b/Enyim.Caching/Memcached/MemcachedNode.cs
@@ -31,6 +31,7 @@ namespace Enyim.Caching.Memcached
         private readonly ISocketPoolConfiguration config;
         private InternalPoolImpl internalPoolImpl;
         private bool isInitialized;
+        private SemaphoreSlim poolInitSemaphore = new SemaphoreSlim(1, 1);
 
         public MemcachedNode(
             EndPoint endpoint,
@@ -96,7 +97,9 @@ namespace Enyim.Caching.Memcached
                     if (this.isDisposed) return false;
 
                     // try to connect to the server
-                    using (var socket = this.CreateSocket()) ;
+                    using (var socket = this.CreateSocket())
+                    {
+                    }
 
                     if (this.internalPoolImpl.IsAlive)
                         return true;
@@ -117,7 +120,7 @@ namespace Enyim.Caching.Memcached
             //could not reconnect
             catch { return false; }
         }
-
+        
         /// <summary>
         /// Acquires a new item from the pool
         /// </summary>
@@ -125,18 +128,52 @@ namespace Enyim.Caching.Memcached
         public IPooledSocketResult Acquire()
         {
             if (!this.isInitialized)
-                lock (this.internalPoolImpl)
-                    if (!this.isInitialized)
-                    {
-                        var startTime = DateTime.Now;
-                        this.internalPoolImpl.InitPool();
-                        this.isInitialized = true;
-                        _logger.LogInformation("MemcachedInitPool-cost: {0}ms", (DateTime.Now - startTime).TotalMilliseconds);
-                    }
-
+            {
+                poolInitSemaphore.Wait();
+                if (!this.isInitialized)
+                {
+                    var startTime = DateTime.Now;
+                    this.internalPoolImpl.InitPool();
+                    this.isInitialized = true;
+                    _logger.LogInformation("MemcachedInitPool-cost: {0}ms", (DateTime.Now - startTime).TotalMilliseconds);
+                    poolInitSemaphore.Release();
+                }
+            }
             try
             {
                 return this.internalPoolImpl.Acquire();
+            }
+            catch (Exception e)
+            {
+                var message = "Acquire failed. Maybe we're already disposed?";
+                _logger.LogError(message, e);
+                var result = new PooledSocketResult();
+                result.Fail(message, e);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Acquires a new item from the pool
+        /// </summary>
+        /// <returns>An <see cref="T:PooledSocket"/> instance which is connected to the memcached server, or <value>null</value> if the pool is dead.</returns>
+        public async Task<IPooledSocketResult> AcquireAsync()
+        {
+            if (!this.isInitialized)
+            {
+                await poolInitSemaphore.WaitAsync();
+                if (!this.isInitialized)
+                {
+                    var startTime = DateTime.Now;
+                    await this.internalPoolImpl.InitPoolAsync();
+                    this.isInitialized = true;
+                    _logger.LogInformation("MemcachedInitPool-cost: {0}ms", (DateTime.Now - startTime).TotalMilliseconds);
+                    poolInitSemaphore.Release();
+                }
+            }
+            try
+            {
+                return await this.internalPoolImpl.AcquireAsync();
             }
             catch (Exception e)
             {
@@ -203,7 +240,7 @@ namespace Enyim.Caching.Memcached
             private MemcachedNode ownerNode;
             private readonly EndPoint _endPoint;
             private readonly TimeSpan queueTimeout;
-            private Semaphore semaphore;
+            private SemaphoreSlim semaphore;
 
             private readonly object initLock = new Object();
 
@@ -227,13 +264,13 @@ namespace Enyim.Caching.Memcached
                 this.minItems = config.MinPoolSize;
                 this.maxItems = config.MaxPoolSize;
 
-                this.semaphore = new Semaphore(maxItems, maxItems);
+                this.semaphore = new SemaphoreSlim(maxItems, maxItems);
                 this.freeItems = new InterlockedStack<PooledSocket>();
 
                 _logger = logger;
                 _isDebugEnabled = _logger.IsEnabled(LogLevel.Debug);
             }
-
+            
             internal void InitPool()
             {
                 try
@@ -262,6 +299,41 @@ namespace Enyim.Caching.Memcached
                 }
             }
 
+            internal async Task InitPoolAsync()
+            {
+                try
+                {
+                    if (this.minItems > 0)
+                    {
+                        for (int i = 0; i < this.minItems; i++)
+                        {
+                            this.freeItems.Push(await this.CreateSocketAsync());
+
+                            // cannot connect to the server
+                            if (!this.isAlive)
+                                break;
+                        }
+                    }
+
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                        _logger.LogDebug("Pool has been inited for {0} with {1} sockets", this.endPoint, this.minItems);
+
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError("Could not init pool.", new EventId(0), e);
+
+                    this.MarkAsDead();
+                }
+            }
+
+            private async Task<PooledSocket> CreateSocketAsync()
+            {
+                var ps = await this.ownerNode.CreateSocketAsync();
+                ps.CleanupCallback = this.ReleaseSocket;
+
+                return ps;
+            }
             private PooledSocket CreateSocket()
             {
                 var ps = this.ownerNode.CreateSocket();
@@ -279,7 +351,7 @@ namespace Enyim.Caching.Memcached
             {
                 get { return this.markedAsDeadUtc; }
             }
-
+            
             /// <summary>
             /// Acquires a new item from the pool
             /// </summary>
@@ -303,7 +375,7 @@ namespace Enyim.Caching.Memcached
 
                 PooledSocket retval = null;
 
-                if (!this.semaphore.WaitOne(this.queueTimeout))
+                if (!this.semaphore.Wait(this.queueTimeout))
                 {
                     message = "Pool is full, timeouting. " + _endPoint;
                     if (_isDebugEnabled) _logger.LogDebug(message);
@@ -369,6 +441,113 @@ namespace Enyim.Caching.Memcached
                 catch (Exception e)
                 {
                     message = "Failed to create socket. " + _endPoint;
+                    _logger.LogError(message, e);
+
+                    // eventhough this item failed the failure policy may keep the pool alive
+                    // so we need to make sure to release the semaphore, so new connections can be
+                    // acquired or created (otherwise dead conenctions would "fill up" the pool
+                    // while the FP pretends that the pool is healthy)
+                    semaphore.Release();
+
+                    this.MarkAsDead();
+                    result.Fail(message);
+                    return result;
+                }
+
+                if (_isDebugEnabled) _logger.LogDebug("Done.");
+
+                return result;
+            }
+
+            /// <summary>
+            /// Acquires a new item from the pool
+            /// </summary>
+            /// <returns>An <see cref="T:PooledSocket"/> instance which is connected to the memcached server, or <value>null</value> if the pool is dead.</returns>
+            public async Task<IPooledSocketResult> AcquireAsync()
+            {
+                var result = new PooledSocketResult();
+                var message = string.Empty;
+
+                if (_isDebugEnabled) _logger.LogDebug("Acquiring stream from pool. " + this.endPoint);
+
+                if (!this.isAlive || this.isDisposed)
+                {
+                    message = "Pool is dead or disposed, returning null. " + this.endPoint;
+                    result.Fail(message);
+
+                    if (_isDebugEnabled) _logger.LogDebug(message);
+
+                    return result;
+                }
+
+                PooledSocket retval = null;
+
+                if (!await this.semaphore.WaitAsync(this.queueTimeout))
+                {
+                    message = "Pool is full, timeouting. " + this.endPoint;
+                    if (_isDebugEnabled) _logger.LogDebug(message);
+                    result.Fail(message, new TimeoutException());
+
+                    // everyone is so busy
+                    return result;
+                }
+
+                // maybe we died while waiting
+                if (!this.isAlive)
+                {
+                    message = "Pool is dead, returning null. " + this.endPoint;
+                    if (_isDebugEnabled) _logger.LogDebug(message);
+                    result.Fail(message);
+
+                    return result;
+                }
+
+                // do we have free items?
+                if (this.freeItems.TryPop(out retval))
+                {
+                    #region [ get it from the pool         ]
+
+                    try
+                    {
+                        retval.Reset();
+
+                        message = "Socket was reset. " + retval.InstanceId;
+                        if (_isDebugEnabled) _logger.LogDebug(message);
+
+                        result.Pass(message);
+                        result.Value = retval;
+                        return result;
+                    }
+                    catch (Exception e)
+                    {
+                        message = "Failed to reset an acquired socket.";
+                        _logger.LogError(message, e);
+
+                        this.MarkAsDead();
+                        result.Fail(message, e);
+                        return result;
+                    }
+
+                    #endregion
+                }
+
+                // free item pool is empty
+                message = "Could not get a socket from the pool, Creating a new item. " + this.endPoint;
+                if (_isDebugEnabled) _logger.LogDebug(message);
+
+
+                try
+                {
+                    // okay, create the new item
+                    var startTime = DateTime.Now;
+                    retval = await this.CreateSocketAsync();
+                    _logger.LogInformation("MemcachedAcquire-CreateSocket: {0}ms", (DateTime.Now - startTime).TotalMilliseconds);
+                    result.Value = retval;
+                    result.Pass();
+                }
+                catch (Exception e)
+                {
+                    message = "Failed to create socket. " + this.endPoint;
                     _logger.LogError(message, e);
 
                     // eventhough this item failed the failure policy may keep the pool alive
@@ -517,11 +696,28 @@ namespace Enyim.Caching.Memcached
         {
             try
             {
-                return new PooledSocket(this.endPoint, this.config.ConnectionTimeout, this.config.ReceiveTimeout, _logger);
+                var ps = new PooledSocket(this.endPoint, this.config.ConnectionTimeout, this.config.ReceiveTimeout, _logger);
+                ps.Connect();
+                return ps;
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, $"Create {nameof(PooledSocket)}");
+                throw;
+            }
+            
+        }
+        protected internal virtual async Task<PooledSocket> CreateSocketAsync()
+        {
+            try
+            {
+                var ps = new PooledSocket(this.endPoint, this.config.ConnectionTimeout, this.config.ReceiveTimeout, _logger);
+                await ps.ConnectAsync();
+                return ps;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(new EventId(this.GetHashCode(), nameof(MemcachedNode)), ex, $"Create {nameof(PooledSocket)}");
                 throw;
             }
         }
@@ -581,11 +777,11 @@ namespace Enyim.Caching.Memcached
 
         }
 
-        protected async virtual Task<IPooledSocketResult> ExecuteOperationAsync(IOperation op)
+        protected virtual async Task<IPooledSocketResult> ExecuteOperationAsync(IOperation op)
         {
             _logger.LogDebug($"ExecuteOperationAsync({op})");
 
-            var result = this.Acquire();
+            var result = await this.AcquireAsync();
             if (result.Success && result.HasValue)
             {
                 try
@@ -630,9 +826,9 @@ namespace Enyim.Caching.Memcached
 
         }
 
-        protected virtual bool ExecuteOperationAsync(IOperation op, Action<bool> next)
+        protected virtual async Task<bool> ExecuteOperationAsync(IOperation op, Action<bool> next)
         {
-            var socket = this.Acquire().Value;
+            var socket = (await this.AcquireAsync()).Value;
             if (socket == null) return false;
 
             //key(string) to buffer(btye[]) 
@@ -698,7 +894,7 @@ namespace Enyim.Caching.Memcached
 
         bool IMemcachedNode.ExecuteAsync(IOperation op, Action<bool> next)
         {
-            return this.ExecuteOperationAsync(op, next);
+            return this.ExecuteOperationAsync(op, next).Result;
         }
 
         event Action<IMemcachedNode> IMemcachedNode.Failed

--- a/Enyim.Caching/Memcached/MemcachedNode.cs
+++ b/Enyim.Caching/Memcached/MemcachedNode.cs
@@ -130,12 +130,19 @@ namespace Enyim.Caching.Memcached
             if (!this.isInitialized)
             {
                 poolInitSemaphore.Wait();
-                if (!this.isInitialized)
+                try
                 {
-                    var startTime = DateTime.Now;
-                    this.internalPoolImpl.InitPool();
-                    this.isInitialized = true;
-                    _logger.LogInformation("MemcachedInitPool-cost: {0}ms", (DateTime.Now - startTime).TotalMilliseconds);
+                    if (!this.isInitialized)
+                    {
+                        var startTime = DateTime.Now;
+                        this.internalPoolImpl.InitPool();
+                        this.isInitialized = true;
+                        _logger.LogInformation("MemcachedInitPool-cost: {0}ms", (DateTime.Now - startTime).TotalMilliseconds);
+                    }
+                }
+                finally
+                {
+                    poolInitSemaphore.Release();
                 }
             }
 
@@ -151,10 +158,6 @@ namespace Enyim.Caching.Memcached
                 result.Fail(message, e);
                 return result;
             }
-            finally
-            {
-                poolInitSemaphore.Release();
-            }
         }
 
         /// <summary>
@@ -166,12 +169,18 @@ namespace Enyim.Caching.Memcached
             if (!this.isInitialized)
             {
                 await poolInitSemaphore.WaitAsync();
-                if (!this.isInitialized)
+                try
                 {
-                    var startTime = DateTime.Now;
-                    await this.internalPoolImpl.InitPoolAsync();
-                    this.isInitialized = true;
-                    _logger.LogInformation("MemcachedInitPool-cost: {0}ms", (DateTime.Now - startTime).TotalMilliseconds);
+                    if (!this.isInitialized)
+                    {
+                        var startTime = DateTime.Now;
+                        await this.internalPoolImpl.InitPoolAsync();
+                        this.isInitialized = true;
+                        _logger.LogInformation("MemcachedInitPool-cost: {0}ms", (DateTime.Now - startTime).TotalMilliseconds);
+                    }
+                }
+                finally
+                {
                     poolInitSemaphore.Release();
                 }
             }

--- a/Enyim.Caching/Memcached/PooledSocket.cs
+++ b/Enyim.Caching/Memcached/PooledSocket.cs
@@ -245,7 +245,7 @@ namespace Enyim.Caching.Memcached
             {
                 try
                 {
-                    int currentRead = await this.inputStream.ReadAsync(buffer, offset, shouldRead);
+                    int currentRead = this.inputStream.Read(buffer, offset, shouldRead);
                     if (currentRead < 1)
                         continue;
 


### PR DESCRIPTION
Use `SemaphoreSlim` to control acquisition of `PooledSocket` in `ExecuteOperationAsync`, this can prevent long time blocking when it under high concurrency.