### PR TITLE
Prevent 'Expected magic value...' exception at failover

### DIFF
--- a/Enyim.Caching/Memcached/PooledSocket.cs
+++ b/Enyim.Caching/Memcached/PooledSocket.cs
@@ -292,8 +292,10 @@ namespace Enyim.Caching.Memcached
                 try
                 {
                     int currentRead = await _inputStream.ReadAsync(buffer, offset, shouldRead);
-                    if (currentRead == count || currentRead < 1)
+                    if (currentRead == count)
                         break;
+                    if (currentRead < 1)
+                        throw new IOException("The socket seems to be disconnected");
 
                     read += currentRead;
                     offset += currentRead;
@@ -330,8 +332,10 @@ namespace Enyim.Caching.Memcached
                 try
                 {
                     int currentRead = _inputStream.Read(buffer, offset, shouldRead);
-                    if (currentRead == count || currentRead < 1)
+                    if (currentRead == count)
                         break;
+                    if (currentRead < 1)
+                        throw new IOException("The socket seems to be disconnected");
 
                     read += currentRead;
                     offset += currentRead;


### PR DESCRIPTION
(in the case of using binary protocol)

When the peer memcached server is down, the PooledSocket.Read may return empty data without exception so BinaryResponse.DeserializeHeader fails to deserialize response data.