### PR TITLE
improve TryGet<T> TryGetWithCas<T> ExecuteTryGet<T> generic support

### DIFF
--- a/Enyim.Caching.Tests/MemcachedClientGetTests.cs
+++ b/Enyim.Caching.Tests/MemcachedClientGetTests.cs
@@ -46,6 +46,19 @@ namespace Enyim.Caching.Tests
         }
 
         [Fact]
+        public void When_Generic_TryGetting_Existing_Item_Value_Is_Not_Null_And_Result_Is_Successful()
+        {
+            var key = GetUniqueKey("get");
+            var value = GetRandomString();
+            var storeResult = Store(key: key, value: value);
+            StoreAssertPass(storeResult);
+
+            string temp;
+            var getResult = _client.ExecuteTryGet(key, out temp);
+            GetAssertPass(getResult, temp);
+        }
+
+        [Fact]
         public void When_Generic_Getting_Existing_Item_Value_Is_Not_Null_And_Result_Is_Successful()
         {
             var key = GetUniqueKey("get");

--- a/Enyim.Caching/IMemcachedClient.cs
+++ b/Enyim.Caching/IMemcachedClient.cs
@@ -26,7 +26,9 @@ namespace Enyim.Caching
         Task<IDictionary<string, T>> GetAsync<T>(IEnumerable<string> keys);
 
         bool TryGet(string key, out object value);
+        bool TryGet<T>(string key, out T value);
         bool TryGetWithCas(string key, out CasResult<object> value);
+        bool TryGetWithCas<T>(string key, out CasResult<T> value);
 
         CasResult<object> GetWithCas(string key);
         CasResult<T> GetWithCas<T>(string key);

--- a/Enyim.Caching/IMemcachedResultsClient.cs
+++ b/Enyim.Caching/IMemcachedResultsClient.cs
@@ -18,6 +18,7 @@ namespace Enyim.Caching
         IDictionary<string, IGetOperationResult> ExecuteGet(IEnumerable<string> keys);
 
         IGetOperationResult ExecuteTryGet(string key, out object value);
+        IGetOperationResult ExecuteTryGet<T>(string key, out T value);
 
         IStoreOperationResult ExecuteStore(StoreMode mode, string key, object value);
         IStoreOperationResult ExecuteStore(StoreMode mode, string key, object value, DateTime expiresAt);

--- a/Enyim.Caching/MemcachedClient.Results.cs
+++ b/Enyim.Caching/MemcachedClient.Results.cs
@@ -145,16 +145,29 @@ namespace Enyim.Caching
 			ulong cas = 0;
 
 			return this.PerformTryGet(key, out cas, out value);
-		}
+        }
 
-		/// <summary>
-		/// Retrieves the specified item from the cache.
-		/// </summary>
-		/// <param name="key">The identifier for the item to retrieve.</param>
-		/// <returns>The retrieved item, or <value>default(T)</value> if the key was not found.</returns>
-		public IGetOperationResult<T> ExecuteGet<T>(string key)
+        /// <summary>
+        /// Tries to get an item from the cache.
+        /// </summary>
+        /// <param name="key">The identifier for the item to retrieve.</param>
+        /// <param name="value">The retrieved item or null if not found.</param>
+        /// <returns>The <value>true</value> if the item was successfully retrieved.</returns>
+        public IGetOperationResult ExecuteTryGet<T>(string key, out T value)
+        {
+            ulong cas = 0;
+
+            return this.PerformTryGet(key, out cas, out value);
+        }
+
+        /// <summary>
+        /// Retrieves the specified item from the cache.
+        /// </summary>
+        /// <param name="key">The identifier for the item to retrieve.</param>
+        /// <returns>The retrieved item, or <value>default(T)</value> if the key was not found.</returns>
+        public IGetOperationResult<T> ExecuteGet<T>(string key)
 		{
-			object tmp;
+            T tmp;
 			var result = new DefaultGetOperationResultFactory<T>().Create();
 
 			var tryGetResult = ExecuteTryGet(key, out tmp);

--- a/Enyim.Caching/MemcachedClientT.cs
+++ b/Enyim.Caching/MemcachedClientT.cs
@@ -280,7 +280,17 @@ namespace Enyim.Caching
             return _memcachedClient.TryGet(key, out value);
         }
 
+        public bool TryGet<T1>(string key, out T1 value)
+        {
+            return _memcachedClient.TryGet(key, out value);
+        }
+
         public bool TryGetWithCas(string key, out CasResult<object> value)
+        {
+            return _memcachedClient.TryGetWithCas(key, out value);
+        }
+
+        public bool TryGetWithCas<T1>(string key, out CasResult<T1> value)
         {
             return _memcachedClient.TryGetWithCas(key, out value);
         }

--- a/Enyim.Caching/NullMemcachedClient.cs
+++ b/Enyim.Caching/NullMemcachedClient.cs
@@ -228,9 +228,21 @@ namespace Enyim.Caching
             return false;
         }
 
+        public bool TryGet<T>(string key, out T value)
+        {
+            value = default;
+            return false;
+        }
+
         public bool TryGetWithCas(string key, out CasResult<object> value)
         {
             value = new CasResult<object>();
+            return false;
+        }
+
+        public bool TryGetWithCas<T>(string key, out CasResult<T> value)
+        {
+            value = new CasResult<T>();
             return false;
         }
 


### PR DESCRIPTION
改进对泛型的支持。see issue https://github.com/cnblogs/EnyimMemcachedCore/issues/123
1. 默认的序列化反序列化在面对非基元类型的时候会以```Bson```这个协议进行序列化和反序列化，而```TryGetWithCas<T>```的实现内部没有透传泛型类型信息给反序列化器，导致反序列化失败。
2. 顺手新增 ```TryGet<T>``` ```ExecuteTryGet<T>``` 泛型支持