### PR TITLE
GetAsync hiding exceptions

### DIFF
--- a/Enyim.Caching/MemcachedClient.cs
+++ b/Enyim.Caching/MemcachedClient.cs
@@ -210,7 +210,7 @@ namespace Enyim.Caching
             catch (Exception ex)
             {
                 _logger.LogError(0, ex, $"{nameof(GetAsync)}(\"{key}\")");
-                result.Fail(ex.Message);
+                result.Fail(ex.Message, ex);
                 return result;
             }
         }


### PR DESCRIPTION
Current GetAsync is handling exceptions but not returning inside `Exception`.