### PR TITLE
fix: fix string.Empty consistency issue

### DIFF
--- a/Enyim.Caching.Tests/MemcachedClientGetTests.cs
+++ b/Enyim.Caching.Tests/MemcachedClientGetTests.cs
@@ -112,6 +112,16 @@ namespace Enyim.Caching.Tests
         }
 
         [Fact]
+        public async Task When_Getting_Empty_String_Async_Result_Is_Successful()
+        {
+            var key = GetUniqueKey("Get");
+            var empty = string.Empty;
+            Store(key: key, value: empty);
+            var getResult = await _client.GetAsync<string>(key);
+            Assert.Equal(getResult.Value, empty);
+        }
+
+        [Fact]
         public async Task GetValueOrCreateAsyncTest()
         {
             var key = "GetValueOrCreateAsyncTest_" + Guid.NewGuid();
@@ -132,7 +142,7 @@ namespace Enyim.Caching.Tests
             var posts = new List<BlogPost>()
             {
                 new BlogPost{ Title = "test title 1", Body = "test body 1" },
-                new BlogPost{ Title = "test title 2", Body = "test body 2" }
+                new BlogPost{ Title = "test title 2", Body = "test body 2" },
             };
 
             return Task.FromResult(posts.AsEnumerable());

--- a/Enyim.Caching.Tests/MemcachedClientGetTests.cs
+++ b/Enyim.Caching.Tests/MemcachedClientGetTests.cs
@@ -117,8 +117,8 @@ namespace Enyim.Caching.Tests
             var key = GetUniqueKey("Get");
             var empty = string.Empty;
             Store(key: key, value: empty);
-            var getResult = await _client.GetAsync<string>(key);
-            Assert.Equal(getResult.Value, empty);
+            var getResult = await _client.GetValueAsync<string>(key);
+            Assert.Equal(getResult, empty);
         }
 
         [Fact]

--- a/Enyim.Caching/Memcached/Transcoders/DefaultTranscoder.cs
+++ b/Enyim.Caching/Memcached/Transcoders/DefaultTranscoder.cs
@@ -30,8 +30,6 @@ namespace Enyim.Caching.Memcached
 
         public virtual T Deserialize<T>(CacheItem item)
         {
-            if (item.Data == null || item.Data.Count == 0) return default(T);
-
             if (typeof(T).GetTypeCode() != TypeCode.Object || typeof(T) == typeof(Byte[]))
             {
                 var value = Deserialize(item);


### PR DESCRIPTION
Keep consistency when store string.Empty using generic methods.

Solves #147 