### PR TITLE
fix GetAsync's return IGetOperation with correct Cas value

### DIFF
--- a/Enyim.Caching.Tests/MemcachedClientCasTests.cs
+++ b/Enyim.Caching.Tests/MemcachedClientCasTests.cs
@@ -1,14 +1,13 @@
 ﻿using Enyim.Caching.Memcached;
+using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Enyim.Caching.Tests
 {
 
-	public class MemcachedClientCasTests : MemcachedClientTestsBase
+    public class MemcachedClientCasTests : MemcachedClientTestsBase
 	{
 
 		[Fact]
@@ -35,7 +34,72 @@ namespace Enyim.Caching.Tests
 			StoreAssertFail(casResult);
 		}
 
-	}
+
+        [Fact]
+        public async Task When_Storing_Item_With_Valid_Cas_Result_Is_Successful_Async()
+        {
+            var key = GetUniqueKey("cas");
+            var value = GetRandomString();
+            var comment = new Comment
+            {
+                Author = key,
+                Text = value
+            };
+
+            var storeResult = Store(StoreMode.Add, key, comment);
+            StoreAssertPass(storeResult);
+
+            var casResult1 = await _client.GetAsync(key);
+            GetAssertPass(casResult1, comment);
+
+            var casResult2 = await _client.GetAsync<Comment>(key);
+            GetAssertPass(casResult2, comment);
+        }
+
+        /// <summary>
+        /// comment
+        /// because <see cref="IMemcachedClient"/> use <see cref="Newtonsoft"/> as default serialization tool,
+        /// so <see cref="IMemcachedClient.GetAsync(string)"/> will return <see cref="IGetOperation"/> with <see cref="JObject"/> as <see cref="IGetOperation.Result"/>'s type.
+        /// </summary>
+        public class Comment : IEquatable<Comment>, IEquatable<JObject>
+        {
+            public string Author { get; set; }
+
+            public string Text { get; set; }
+
+            public bool Equals(Comment other)
+            {
+                return other != null && other.Author == Author && other.Text == Text;
+            }
+
+            public bool Equals(JObject other)
+            {
+                return Equals(other?.ToObject<Comment>());
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (obj == null)
+                {
+                    return false;
+                }
+                if (obj is Comment comment)
+                {
+                    return Equals(comment);
+                }
+                if (obj is JObject jObject)
+                {
+                    return Equals(jObject);
+                }
+                return false;
+            }
+
+            public override int GetHashCode()
+            {
+                return HashCode.Combine(Author, Text);
+            }
+        }
+    }
 }
 
 #region [ License information          ]

--- a/Enyim.Caching.Tests/MemcachedClientMutateTests.cs
+++ b/Enyim.Caching.Tests/MemcachedClientMutateTests.cs
@@ -36,12 +36,16 @@ namespace Enyim.Caching.Tests
         {
             var key = GetUniqueKey("touch");
             await _client.AddAsync(key, "value", 1);
-            Assert.True((await _client.GetAsync<string>(key)).Success);
+            var operationResult = await _client.GetAsync<string>(key);
+            Assert.True(operationResult.Success);
+            Assert.NotEqual(0UL, operationResult.Cas);
             var result = await _client.TouchAsync(key, TimeSpan.FromSeconds(60));
             await Task.Delay(1010);
             Assert.True(result.Success, "Success was false");
             Assert.True((result.StatusCode ?? 0) == 0, "StatusCode was not null or 0");
-            Assert.True((await _client.GetAsync<string>(key)).Success);
+            operationResult = await _client.GetAsync<string>(key);
+            Assert.True(operationResult.Success);
+            Assert.NotEqual(0UL, operationResult.Cas);
         }
     }
 }

--- a/Enyim.Caching.Tests/MemcachedClientTestsBase.cs
+++ b/Enyim.Caching.Tests/MemcachedClientTestsBase.cs
@@ -105,6 +105,14 @@ namespace Enyim.Caching.Tests
             Assert.Equal(expectedValue, result.Value);
         }
 
+        protected void GetAssertPass<T>(IGetOperationResult<T> result, T expectedValue)
+        {
+            Assert.True(result.Success, "Success was false");
+            Assert.True(result.Cas > 0, "Cas value was 0");
+            Assert.True((result.StatusCode ?? 0) == 0, "StatusCode was neither 0 nor null");
+            Assert.Equal(expectedValue, result.Value);
+        }
+
         protected void GetAssertFail(IGetOperationResult result)
         {
             Assert.False(result.Success, "Success was true");

--- a/Enyim.Caching/IMemcachedClient.cs
+++ b/Enyim.Caching/IMemcachedClient.cs
@@ -17,6 +17,7 @@ namespace Enyim.Caching
         bool Replace(string key, object value, int cacheSeconds);
         Task<bool> ReplaceAsync(string key, object value, int cacheSeconds);
 
+        Task<IGetOperationResult> GetAsync(string key);
         Task<IGetOperationResult<T>> GetAsync<T>(string key);
         Task<T> GetValueAsync<T>(string key);
         Task<T> GetValueOrCreateAsync<T>(string key, int cacheSeconds, Func<Task<T>> generator);

--- a/Enyim.Caching/MemcachedClientT.cs
+++ b/Enyim.Caching/MemcachedClientT.cs
@@ -120,6 +120,11 @@ namespace Enyim.Caching
             return _memcachedClient.Get<T1>(keys);
         }
 
+        public Task<IGetOperationResult> GetAsync(string key)
+        {
+            return _memcachedClient.GetAsync(key);
+        }
+
         public Task<IGetOperationResult<T1>> GetAsync<T1>(string key)
         {
             return _memcachedClient.GetAsync<T1>(key);

--- a/Enyim.Caching/NullMemcachedClient.cs
+++ b/Enyim.Caching/NullMemcachedClient.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 using Enyim.Caching.Memcached;
 using Enyim.Caching.Memcached.Results;
@@ -102,6 +100,13 @@ namespace Enyim.Caching
         public T Get<T>(string key)
         {
             return default(T);
+        }
+
+        public Task<IGetOperationResult> GetAsync(string key)
+        {
+            var result = new DefaultGetOperationResultFactory().Create();
+            result.Success = false;
+            return Task.FromResult(result);
         }
 
         public async Task<IGetOperationResult<T>> GetAsync<T>(string key)


### PR DESCRIPTION
1.  fix ```Task<IGetOperationResult<T>> IMemcachedClient.GetAsync<T>(string key)```, if ```key``` exist then ```IGetOperationResult<T>.Cas``` should greater than ```0```  when ```key``` exist
2.  add ```Task<IGetOperationResult> IMemcachedClient.GetAsync(string key)```, ```IGetOperationResult.Cas``` should greater than ```0``` when ```key``` exist