### PR TITLE
Replace Microsoft.AspNetCore.Http.Abstractions with Microsoft.AspNetCore.App

### DIFF
--- a/Enyim.Caching/Enyim.Caching.csproj
+++ b/Enyim.Caching/Enyim.Caching.csproj
@@ -15,7 +15,11 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />


### PR DESCRIPTION
Last version of `Microsoft.AspNetCore.Http.Abstractions` was released as part of .NET Core 2.2 and have been replaced by Microsoft.AspNetCore.App (See https://github.com/dotnet/aspnetcore/issues/3756  for more details).

Subsequently .NET Core 2.2 has run out of support almost three years ago.

`Microsoft.AspNetCore.Http.Abstractions` has a dependency on [System.Text.Encodings.Web@4.5.0](https://www.nuget.org/packages/System.Text.Encodings.Web/4.5.0) that have a [critical security vulnerability](https://security.snyk.io/vuln/SNYK-DOTNET-SYSTEMTEXTENCODINGSWEB-1253267). 

This change will fix vulnerability issue for anyone who is using .NET 6. 