### PR TITLE
Added an option to specify max idle time for a pooled socket.

### DIFF
--- a/src/Enyim.Caching/Configuration/ISocketPoolConfiguration.cs
+++ b/src/Enyim.Caching/Configuration/ISocketPoolConfiguration.cs
@@ -68,6 +68,16 @@ namespace Enyim.Caching.Configuration
             set;
         }
 
+        /// <summary>
+        /// Gets or sets a value that specified the amount of time after which a pooled socket will be discarded. Discarding will only happen at the time when the socket is picked up from the socket pool, e.g. it depends on usage.
+        /// </summary>
+        /// <returns>The value of the connection idle timeout.</returns>
+        TimeSpan ConnectionIdleTimeout
+        {
+            get;
+            set;
+        }
+
         TimeSpan InitPoolTimeout { get; set; }
 
         INodeFailurePolicyFactory FailurePolicyFactory { get; set; }

--- a/src/Enyim.Caching/Configuration/MemcachedClientConfiguration.cs
+++ b/src/Enyim.Caching/Configuration/MemcachedClientConfiguration.cs
@@ -81,6 +81,9 @@ namespace Enyim.Caching.Configuration
                 SocketPool.QueueTimeout = options.SocketPool.QueueTimeout;
                 _logger.LogInformation($"{nameof(SocketPool.QueueTimeout)}: {SocketPool.QueueTimeout}");
 
+                SocketPool.ConnectionIdleTimeout = options.SocketPool.ConnectionIdleTimeout;
+                _logger.LogInformation($"{nameof(SocketPool.ConnectionIdleTimeout)}: {SocketPool.ConnectionIdleTimeout}");
+
                 SocketPool.InitPoolTimeout = options.SocketPool.InitPoolTimeout;
 
                 SocketPool.FailurePolicyFactory = options.SocketPool.FailurePolicyFactory;

--- a/src/Enyim.Caching/Configuration/MemcachedClientOptions.cs
+++ b/src/Enyim.Caching/Configuration/MemcachedClientOptions.cs
@@ -72,6 +72,7 @@ namespace Enyim.Caching.Configuration
         public TimeSpan ReceiveTimeout { get; set; } = new TimeSpan(0, 0, 10);
         public TimeSpan DeadTimeout { get; set; } = new TimeSpan(0, 0, 10);
         public TimeSpan QueueTimeout { get; set; } = new TimeSpan(0, 0, 0, 0, 100);
+        public TimeSpan ConnectionIdleTimeout { get; set; } = TimeSpan.Zero;
         public TimeSpan InitPoolTimeout { get; set; } = new TimeSpan(0, 1, 0);
         public INodeFailurePolicyFactory FailurePolicyFactory { get; set; } = new ThrottlingFailurePolicyFactory(5, TimeSpan.FromMilliseconds(2000));
 
@@ -93,6 +94,7 @@ namespace Enyim.Caching.Configuration
             CheckTimeout(nameof(ReceiveTimeout), ReceiveTimeout);
             CheckTimeout(nameof(DeadTimeout), DeadTimeout);
             CheckTimeout(nameof(QueueTimeout), QueueTimeout);
+            CheckTimeout(nameof(ConnectionIdleTimeout), ConnectionIdleTimeout);
         }
 
         private void CheckTimeout(string paramName, TimeSpan value)

--- a/src/Enyim.Caching/Configuration/SocketPoolConfiguration.cs
+++ b/src/Enyim.Caching/Configuration/SocketPoolConfiguration.cs
@@ -15,6 +15,7 @@ namespace Enyim.Caching.Configuration
         private TimeSpan _receiveTimeout = new TimeSpan(0, 0, 10);
         private TimeSpan _deadTimeout = new TimeSpan(0, 0, 10);
         private TimeSpan _queueTimeout = new TimeSpan(0, 0, 0, 0, 100);
+        private TimeSpan _connectionIdleTimeout = TimeSpan.Zero;
         private TimeSpan _initPoolTimeout = new TimeSpan(0, 1, 0);
         private INodeFailurePolicyFactory _failurePolicyFactory = new ThrottlingFailurePolicyFactory(5, TimeSpan.FromMilliseconds(2000));
 
@@ -92,6 +93,18 @@ namespace Enyim.Caching.Configuration
                     throw new ArgumentOutOfRangeException("value", "value must be positive");
 
                 _deadTimeout = value;
+            }
+        }
+
+        TimeSpan ISocketPoolConfiguration.ConnectionIdleTimeout
+        {
+            get { return _connectionIdleTimeout; }
+            set
+            {
+                if (value < TimeSpan.Zero)
+                    throw new ArgumentOutOfRangeException("value", "value must be positive");
+
+                _connectionIdleTimeout = value;
             }
         }
 

--- a/src/Enyim.Caching/Memcached/PooledSocket.cs
+++ b/src/Enyim.Caching/Memcached/PooledSocket.cs
@@ -176,6 +176,13 @@ namespace Enyim.Caching.Memcached
             get { return _socket.Available; }
         }
 
+        public DateTime LastUsed { get; set; } = DateTime.UtcNow;
+
+        public void UpdateLastUsed()
+        {
+            LastUsed = DateTime.UtcNow;
+        }
+
         public void Reset()
         {
             // _inputStream.Flush();

--- a/test/Enyim.Caching.Tests/MemcachedClientCasTests.cs
+++ b/test/Enyim.Caching.Tests/MemcachedClientCasTests.cs
@@ -6,33 +6,31 @@ using Xunit;
 
 namespace Enyim.Caching.Tests
 {
-
     public class MemcachedClientCasTests : MemcachedClientTestsBase
-	{
+    {
+        [Fact]
+        public void When_Storing_Item_With_Valid_Cas_Result_Is_Successful()
+        {
+            var key = GetUniqueKey("cas");
+            var value = GetRandomString();
+            var storeResult = Store(StoreMode.Add, key, value);
+            StoreAssertPass(storeResult);
 
-		[Fact]
-		public void When_Storing_Item_With_Valid_Cas_Result_Is_Successful()
-		{
-			var key = GetUniqueKey("cas");
-			var value = GetRandomString();
-			var storeResult = Store(StoreMode.Add, key, value);
-			StoreAssertPass(storeResult);
+            var casResult = _client.ExecuteCas(StoreMode.Set, key, value, storeResult.Cas);
+            StoreAssertPass(casResult);
+        }
 
-			var casResult = _client.ExecuteCas(StoreMode.Set, key, value, storeResult.Cas);
-			StoreAssertPass(casResult);
-		}
+        [Fact]
+        public void When_Storing_Item_With_Invalid_Cas_Result_Is_Not_Successful()
+        {
+            var key = GetUniqueKey("cas");
+            var value = GetRandomString();
+            var storeResult = Store(StoreMode.Add, key, value);
+            StoreAssertPass(storeResult);
 
-		[Fact]
-		public void When_Storing_Item_With_Invalid_Cas_Result_Is_Not_Successful()
-		{
-			var key = GetUniqueKey("cas");
-			var value = GetRandomString();
-			var storeResult = Store(StoreMode.Add, key, value);
-			StoreAssertPass(storeResult);
-
-			var casResult = _client.ExecuteCas(StoreMode.Set, key, value, storeResult.Cas - 1);
-			StoreAssertFail(casResult);
-		}
+            var casResult = _client.ExecuteCas(StoreMode.Set, key, value, storeResult.Cas - 1);
+            StoreAssertFail(casResult);
+        }
 
 
         [Fact]

--- a/test/Enyim.Caching.Tests/MemcachedClientTestsBase.cs
+++ b/test/Enyim.Caching.Tests/MemcachedClientTestsBase.cs
@@ -26,7 +26,7 @@ namespace Enyim.Caching.Tests
                 onAddEnyimMemcached?.Invoke(options);
             });
 
-            services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Information).AddConsole());
+            services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Warning).AddConsole());
             IServiceProvider serviceProvider = services.BuildServiceProvider();
             _client = serviceProvider.GetService<IMemcachedClient>() as MemcachedClient;
         }

--- a/test/MemcachedTest/FailurePolicyTest.cs
+++ b/test/MemcachedTest/FailurePolicyTest.cs
@@ -54,7 +54,7 @@ namespace MemcachedTest
         {
             IServiceCollection services = new ServiceCollection();
             services.AddEnyimMemcached(options => options.AddServer("localhost", 11212));
-            services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Debug).AddConsole());
+            services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Warning).AddConsole());
             IServiceProvider serviceProvider = services.BuildServiceProvider();
 
             var config = serviceProvider.GetService<IMemcachedClientConfiguration>();

--- a/test/MemcachedTest/MemcachedClientTest.cs
+++ b/test/MemcachedTest/MemcachedClientTest.cs
@@ -29,12 +29,12 @@ namespace MemcachedTest
                 //    options.Transcoder = "BinaryFormatterTranscoder";
                 //}
             });
-            if(useBinaryFormatterTranscoder)
+            if (useBinaryFormatterTranscoder)
             {
-                services.AddSingleton<ITranscoder,BinaryFormatterTranscoder>();
+                services.AddSingleton<ITranscoder, BinaryFormatterTranscoder>();
             }
 
-            services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Information).AddConsole());
+            services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Warning).AddConsole());
 
             IServiceProvider serviceProvider = services.BuildServiceProvider();
             var client = serviceProvider.GetService<IMemcachedClient>() as MemcachedClient;
@@ -336,7 +336,7 @@ namespace MemcachedTest
                 await Task.WhenAll(tasks);
 
                 foreach (var task in tasks)
-                { 
+                {
                     Assert.True(await task, "Store failed");
                 }
 
@@ -356,7 +356,7 @@ namespace MemcachedTest
                     tasks.Add(client.RemoveAsync(key));
                 }
 
-                await Task.WhenAll(tasks);                
+                await Task.WhenAll(tasks);
             }
         }
 

--- a/test/MemcachedTest/MemcachedNodeTests.cs
+++ b/test/MemcachedTest/MemcachedNodeTests.cs
@@ -38,10 +38,6 @@ namespace MemcachedTest
             var logMessage = $"Connection idle timeout {idleTimeout} reached";
             await client.GetAsync(Guid.NewGuid().ToString());
 
-            await Task.Delay(1000);
-            await client.GetAsync(Guid.NewGuid().ToString());
-            Assert.DoesNotContain(logMessage, sw.ToString());
-
             await Task.Delay(2100);
             await client.GetAsync(Guid.NewGuid().ToString());
             Assert.Contains(logMessage, sw.ToString());

--- a/test/MemcachedTest/MemcachedNodeTests.cs
+++ b/test/MemcachedTest/MemcachedNodeTests.cs
@@ -1,0 +1,52 @@
+﻿using Enyim.Caching;
+using Enyim.Caching.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MemcachedTest
+{
+    public class MemcachedNodeTests
+    {
+        [Fact]
+        public async Task ConnectionIdleTimeout_reached()
+        {
+            IServiceCollection services = new ServiceCollection();
+            var idleTimeout = TimeSpan.FromSeconds(2);
+            services.AddEnyimMemcached(options =>
+            {
+                options.AddServer("memcached", 11211);
+                options.SocketPool = new SocketPoolOptions
+                {
+                    ConnectionIdleTimeout = idleTimeout
+                };
+            });
+
+            var originConsoleOut = Console.Out;
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
+            services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Information).AddConsole());
+            IServiceProvider sp = services.BuildServiceProvider();
+            var client = sp.GetRequiredService<IMemcachedClient>() as MemcachedClient;
+
+            var logMessage = $"Connection idle timeout {idleTimeout} reached";
+            await client.GetAsync(Guid.NewGuid().ToString());
+
+            await Task.Delay(1000);
+            await client.GetAsync(Guid.NewGuid().ToString());
+            Assert.DoesNotContain(logMessage, sw.ToString());
+
+            await Task.Delay(2100);
+            await client.GetAsync(Guid.NewGuid().ToString());
+            Assert.Contains(logMessage, sw.ToString());
+
+            Console.SetOut(originConsoleOut);
+        }
+    }
+}


### PR DESCRIPTION
When memcached nodes in a large memcached cluster are intentionally restarted, like a couple every day, connections to those nodes become stale. This change is to add an option to discard pooled sockets if they have not been picked up from the pool in the recent time - in our case this would be about a minute. Those "old" sockets are very likely to become stale (since they are rarely picked up from the _freeItems stack - that only happens during occasional spikes in server load).

Added an option to specify max idle time for a pooled socket. 
Default value is zero, which turns this feature off.
Enforcement is done at the time of picking the socket out of the pool, not by timer.