### PR TITLE
Fix PerformStore log message

### DIFF
--- a/src/Enyim.Caching/MemcachedClient.cs
+++ b/src/Enyim.Caching/MemcachedClient.cs
@@ -5,11 +5,8 @@ using Enyim.Caching.Memcached.Results.Extensions;
 using Enyim.Caching.Memcached.Results.Factories;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -678,13 +675,17 @@ namespace Enyim.Caching
             {
                 CacheItem item;
 
-                try { item = _transcoder.Serialize(value); }
-                catch (Exception e)
+                try
                 {
-                    _logger.LogError(0, ex, "PerformStore failed ({err})", ex.Message);
+                    item = _transcoder.Serialize(value);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "PerformStore failed with '{key}' key", key);
+
                     if (!_suppressException) throw;
 
-                    result.Fail("PerformStore failed", e);
+                    result.Fail("PerformStore failed", ex);
                     return result;
                 }
 

--- a/src/Enyim.Caching/MemcachedClient.cs
+++ b/src/Enyim.Caching/MemcachedClient.cs
@@ -681,7 +681,7 @@ namespace Enyim.Caching
                 try { item = _transcoder.Serialize(value); }
                 catch (Exception e)
                 {
-                    _logger.LogError("PerformStore", e);
+                    _logger.LogError(0, ex, "PerformStore failed ({err})", ex.Message);
                     if (!_suppressException) throw;
 
                     result.Fail("PerformStore failed", e);


### PR DESCRIPTION
The arguments to this LogError call are out of order. The resulting message outputs "PerformStore" with no cause or trace. Someone previously reported this in issue #61, but it was closed for some reason.

Note, I'm not set up to build enyim myself, so I can't test the fix. You can reproduce the offending message by tripping an exception in this block. One way to do that is to try to store an object that is not marked [serializable] using the BinaryFormatterTranscoder.

I notice tags for 2.x and 3.x. I'm not sure if 2.x is still being maintained, but I based off 2.7.0 since that's what we're using.