### PR TITLE
Allow to provide SslClientAuthenticationOptions when leveraging SslStream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/bin/*
 **/obj/*
+.DS_Store*
 TestResults/*
 *.suo
 *.user

--- a/src/Enyim.Caching/Configuration/IMemcachedClientConfiguration.cs
+++ b/src/Enyim.Caching/Configuration/IMemcachedClientConfiguration.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.Security;
 using Enyim.Caching.Memcached;
 
 namespace Enyim.Caching.Configuration
@@ -47,6 +48,8 @@ namespace Enyim.Caching.Configuration
         bool UseIPv6 { get; }
 
         bool SuppressException { get; }
+
+        SslClientAuthenticationOptions SslClientAuth { get; }
     }
 }
 

--- a/src/Enyim.Caching/Configuration/MemcachedClientConfiguration.cs
+++ b/src/Enyim.Caching/Configuration/MemcachedClientConfiguration.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Configuration;
 using System.Linq;
+using System.Net.Security;
 using System.Net.Sockets;
 using Enyim.Caching.Memcached.Transcoders;
 
@@ -123,6 +124,7 @@ namespace Enyim.Caching.Configuration
             UseSslStream = options.UseSslStream;
             UseIPv6 = options.UseIPv6;
             SuppressException = options.SuppressException;
+            SslClientAuth = options.SslClientAuth;
 
             if (!string.IsNullOrEmpty(options.KeyTransformer))
             {
@@ -351,6 +353,7 @@ namespace Enyim.Caching.Configuration
         public bool UseSslStream { get; private set; }
         public bool UseIPv6 { get; private set; }
         public bool SuppressException { get; private set; }
+        public SslClientAuthenticationOptions SslClientAuth { get; private set; }
 
         #endregion
     }

--- a/src/Enyim.Caching/Configuration/MemcachedClientOptions.cs
+++ b/src/Enyim.Caching/Configuration/MemcachedClientOptions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Security;
 using System.Threading.Tasks;
 
 namespace Enyim.Caching.Configuration
@@ -26,6 +27,8 @@ namespace Enyim.Caching.Configuration
         public bool UseIPv6 { get; set; }
 
         public bool SuppressException { get; set; } = true;
+
+        public SslClientAuthenticationOptions SslClientAuth { get; set; }
 
         public IProviderFactory<IMemcachedNodeLocator> NodeLocatorFactory { get; set; }
 

--- a/src/Enyim.Caching/Memcached/DefaultServerPool.cs
+++ b/src/Enyim.Caching/Memcached/DefaultServerPool.cs
@@ -50,7 +50,7 @@ namespace Enyim.Caching.Memcached
 
         protected virtual IMemcachedNode CreateNode(EndPoint endpoint)
         {
-            return new MemcachedNode(endpoint, _configuration.SocketPool, _logger, _configuration.UseSslStream, _configuration.UseIPv6);
+            return new MemcachedNode(endpoint, _configuration.SocketPool, _logger, _configuration.UseSslStream, _configuration.UseIPv6, _configuration.SslClientAuth);
         }
 
         private void rezCallback(object state)

--- a/src/Enyim.Caching/Memcached/MemcachedNode.cs
+++ b/src/Enyim.Caching/Memcached/MemcachedNode.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
+using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.Serialization;
 using System.Security;
@@ -37,16 +38,19 @@ namespace Enyim.Caching.Memcached
         private readonly TimeSpan _initPoolTimeout;
         private bool _useSslStream;
         private bool _useIPv6;
+        private readonly SslClientAuthenticationOptions _sslClientAuthOptions;
 
         public MemcachedNode(
             EndPoint endpoint,
             ISocketPoolConfiguration socketPoolConfig,
             ILogger logger,
             bool useSslStream,
-            bool useIPv6)
+            bool useIPv6,
+            SslClientAuthenticationOptions sslClientAuthOptions)
         {
             _endPoint = endpoint;
             _useSslStream = useSslStream;
+            _sslClientAuthOptions = sslClientAuthOptions;
             EndPointString = endpoint?.ToString().Replace("Unspecified/", string.Empty);
             _config = socketPoolConfig;
 
@@ -859,7 +863,7 @@ namespace Enyim.Caching.Memcached
         {
             try
             {
-                var ps = new PooledSocket(_endPoint, _config.ConnectionTimeout, _config.ReceiveTimeout, _logger, _useSslStream, _useIPv6);
+                var ps = new PooledSocket(_endPoint, _config.ConnectionTimeout, _config.ReceiveTimeout, _logger, _useSslStream, _useIPv6, _sslClientAuthOptions);
                 ps.Connect();
                 return ps;
             }
@@ -875,7 +879,7 @@ namespace Enyim.Caching.Memcached
         {
             try
             {
-                var ps = new PooledSocket(_endPoint, _config.ConnectionTimeout, _config.ReceiveTimeout, _logger, _useSslStream, _useIPv6);
+                var ps = new PooledSocket(_endPoint, _config.ConnectionTimeout, _config.ReceiveTimeout, _logger, _useSslStream, _useIPv6, _sslClientAuthOptions);
                 await ps.ConnectAsync();
                 return ps;
             }

--- a/src/Enyim.Caching/Memcached/PooledSocket.cs
+++ b/src/Enyim.Caching/Memcached/PooledSocket.cs
@@ -27,13 +27,22 @@ namespace Enyim.Caching.Memcached
 
         private NetworkStream _inputStream;
         private SslStream _sslStream;
+        private readonly SslClientAuthenticationOptions _sslClientAuthOptions;
 
-        public PooledSocket(EndPoint endpoint, TimeSpan connectionTimeout, TimeSpan receiveTimeout, ILogger logger, bool useSslStream, bool useIPv6)
+        public PooledSocket(EndPoint endpoint, TimeSpan connectionTimeout, TimeSpan receiveTimeout, ILogger logger, bool useSslStream, bool useIPv6, SslClientAuthenticationOptions sslClientAuthOptions)
         {
             _logger = logger;
             _isAlive = true;
             _useSslStream = useSslStream;
             _useIPv6 = useIPv6;
+            _sslClientAuthOptions = sslClientAuthOptions;
+
+            if (_useSslStream && _sslClientAuthOptions == null)
+                // When not provided, create a default instance with target host set to the endpoint's host
+                sslClientAuthOptions = new SslClientAuthenticationOptions
+                {
+                    TargetHost = ((DnsEndPoint)_endpoint).Host,
+                };
 
             var socket = new Socket(useIPv6 ? AddressFamily.InterNetworkV6 : AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
@@ -99,7 +108,7 @@ namespace Enyim.Caching.Memcached
                 if (_useSslStream)
                 {
                     _sslStream = new SslStream(new NetworkStream(_socket));
-                    _sslStream.AuthenticateAsClient(((DnsEndPoint)_endpoint).Host);
+                    _sslStream.AuthenticateAsClient(_sslClientAuthOptions);
                 }
                 else
                 {
@@ -158,7 +167,7 @@ namespace Enyim.Caching.Memcached
                 if (_useSslStream)
                 {
                     _sslStream = new SslStream(new NetworkStream(_socket));
-                    await _sslStream.AuthenticateAsClientAsync(((DnsEndPoint)_endpoint).Host);
+                    await _sslStream.AuthenticateAsClientAsync(_sslClientAuthOptions);
                 }
                 else
                 {

--- a/src/Enyim.Caching/Memcached/Protocol/Binary/BinaryNode.cs
+++ b/src/Enyim.Caching/Memcached/Protocol/Binary/BinaryNode.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
+using System.Net.Security;
 using System.Threading;
 using Enyim.Caching.Configuration;
 using Enyim.Collections;
@@ -25,8 +26,9 @@ namespace Enyim.Caching.Memcached.Protocol.Binary
             ISaslAuthenticationProvider authenticationProvider,
             ILogger logger,
             bool useSslStream,
-            bool useIPv6)
-            : base(endpoint, config, logger, useSslStream, useIPv6)
+            bool useIPv6,
+            SslClientAuthenticationOptions sslClientAuthOptions)
+            : base(endpoint, config, logger, useSslStream, useIPv6, sslClientAuthOptions)
         {
             _authenticationProvider = authenticationProvider;
             _logger = logger;

--- a/src/Enyim.Caching/Memcached/Protocol/Binary/BinaryPool.cs
+++ b/src/Enyim.Caching/Memcached/Protocol/Binary/BinaryPool.cs
@@ -29,7 +29,7 @@ namespace Enyim.Caching.Memcached.Protocol.Binary
 
         protected override IMemcachedNode CreateNode(EndPoint endpoint)
         {
-            return new BinaryNode(endpoint, _configuration.SocketPool, _authenticationProvider, _logger, _configuration.UseSslStream, _configuration.UseIPv6);
+            return new BinaryNode(endpoint, _configuration.SocketPool, _authenticationProvider, _logger, _configuration.UseSslStream, _configuration.UseIPv6, _configuration.SslClientAuth);
         }
 
         private static ISaslAuthenticationProvider GetProvider(IMemcachedClientConfiguration configuration)


### PR DESCRIPTION
It is currently not possible to tune the SSL client authentication options when connecting to a Memcached server with SSL in place.

One of my needs is to be able to provide custom certificate validation callbacks to the pooled socket object so that I can ignore certificate errors during some local tests for example (it is particularly the case when you want to connect to an Amazon ElastiCache for Memcached SSL cluster from your local machine through a SSH tunnel: you'll get errors because localhost does not match the hostname defined in the server certificate).

This PR introduces a new `SslClientAuth` property in `MemcachedClientOptions` class so that you can define such aspects.

Example of configuration with a callback to ignore certificate validation issues:

```
IOptions<MemcachedClientOptions> optionsAccessor = Options.Create(new MemcachedClientOptions
{
    UseSslStream = true,
    SslClientAuth = new SslClientAuthenticationOptions
    {
        TargetHost = "localhost",
        RemoteCertificateValidationCallback = new RemoteCertificateValidationCallback(
            (sender, certificate, chain, sslPolicyErrors) => true),
    },
    ...
});
```

Properties supported by `SslClientAuthenticationOptions` class are documented here: 
<https://learn.microsoft.com/en-us/dotnet/api/system.net.security.sslclientauthenticationoptions?view=net-8.0#properties>