### PR TITLE
fix: re-implement sslStream initialization for framework versions < 5.0

### DIFF
--- a/src/Enyim.Caching/Memcached/PooledSocket.cs
+++ b/src/Enyim.Caching/Memcached/PooledSocket.cs
@@ -118,19 +118,21 @@ namespace Enyim.Caching.Memcached
 
             if (success)
             {
-#if NET5_0_OR_GREATER
                 if (_useSslStream)
                 {
                     _sslStream = new SslStream(new NetworkStream(_socket));
-                    _sslStream.AuthenticateAsClient(_sslClientAuthOptions);
+                    _sslStream.AuthenticateAsClient(
+#if NET5_0_OR_GREATER
+                        _sslClientAuthOptions
+#else
+                        ((DnsEndPoint)_endpoint).Host
+#endif
+                        );
                 }
                 else
                 {
                     _inputStream = new NetworkStream(_socket);
                 }
-#else
-                _inputStream = new NetworkStream(_socket);
-#endif
             }
             else
             {
@@ -182,19 +184,21 @@ namespace Enyim.Caching.Memcached
 
             if (success)
             {
-#if NET5_0_OR_GREATER
                 if (_useSslStream)
                 {
                     _sslStream = new SslStream(new NetworkStream(_socket));
-                    await _sslStream.AuthenticateAsClientAsync(_sslClientAuthOptions);
+                    await _sslStream.AuthenticateAsClientAsync(
+#if NET5_0_OR_GREATER
+                        _sslClientAuthOptions
+#else
+                        ((DnsEndPoint)_endpoint).Host
+#endif
+                        );
                 }
                 else
                 {
                     _inputStream = new NetworkStream(_socket);
                 }
-#else
-                _inputStream = new NetworkStream(_socket);
-#endif
             }
             else
             {


### PR DESCRIPTION
After #228  sslStream support for Frameworks < 5.0 was broken - sslStream remains uninitialized due to preprocessor directives.

Re-implemented sslStream initialization and replaced `SslClientAuthenticationOptions` with `targetHost` on client authentication (SslClientAuthenticationOptions only available with NET Standard 2.1)
