### PR TITLE
Configure await false everywhere

### DIFF
--- a/src/Enyim.Caching/DistributedCache.cs
+++ b/src/Enyim.Caching/DistributedCache.cs
@@ -24,11 +24,11 @@ namespace Enyim.Caching
 
         async Task<byte[]> IDistributedCache.GetAsync(string key, CancellationToken token = default)
         {
-            var value = await GetValueAsync<byte[]>(key);
+            var value = await GetValueAsync<byte[]>(key).ConfigureAwait(false);
 
             if (value != null)
             {
-                await RefreshAsync(key);
+                await RefreshAsync(key).ConfigureAwait(false);
             }
 
             return value;
@@ -58,17 +58,17 @@ namespace Enyim.Caching
         {
             if (!HasSlidingExpiration(options))
             {
-                await PerformStoreAsync(StoreMode.Set, key, value, 0);
+                await PerformStoreAsync(StoreMode.Set, key, value, 0).ConfigureAwait(false);
                 return;
             }
 
             var expiration = GetExpiration(options);
-            await PerformStoreAsync(StoreMode.Set, key, value, expiration);
+            await PerformStoreAsync(StoreMode.Set, key, value, expiration).ConfigureAwait(false);
 
             if (options.SlidingExpiration.HasValue)
             {
                 var sldExp = options.SlidingExpiration.Value;
-                await AddAsync(GetSlidingExpirationKey(key), sldExp.ToString(), sldExp);
+                await AddAsync(GetSlidingExpirationKey(key), sldExp.ToString(), sldExp).ConfigureAwait(false);
             }
         }
 
@@ -108,15 +108,15 @@ namespace Enyim.Caching
         public async Task RefreshAsync(string key, CancellationToken token = default)
         {
             var sldExpKey = GetSlidingExpirationKey(key);
-            var sldExpStr = await GetValueAsync<string>(sldExpKey);
+            var sldExpStr = await GetValueAsync<string>(sldExpKey).ConfigureAwait(false);
             if (!string.IsNullOrEmpty(sldExpStr)
                 && TimeSpan.TryParse(sldExpStr, out var sldExp))
             {
-                var value = (await GetAsync(key)).Value;
+                var value = (await GetAsync(key).ConfigureAwait(false)).Value;
                 if (value != null)
                 {
-                    await ReplaceAsync(key, value, sldExp);
-                    await ReplaceAsync(sldExpKey, sldExpStr, sldExp);
+                    await ReplaceAsync(key, value, sldExp).ConfigureAwait(false);
+                    await ReplaceAsync(sldExpKey, sldExpStr, sldExp).ConfigureAwait(false);
                 }
             }
         }
@@ -129,8 +129,8 @@ namespace Enyim.Caching
 
         async Task IDistributedCache.RemoveAsync(string key, CancellationToken token = default)
         {
-            await RemoveAsync(key);
-            await RemoveAsync(GetSlidingExpirationKey(key));
+            await RemoveAsync(key).ConfigureAwait(false);
+            await RemoveAsync(GetSlidingExpirationKey(key)).ConfigureAwait(false);
         }
 
         private uint GetExpiration(DistributedCacheEntryOptions options)

--- a/src/Enyim.Caching/Memcached/PooledSocket.cs
+++ b/src/Enyim.Caching/Memcached/PooledSocket.cs
@@ -156,9 +156,9 @@ namespace Enyim.Caching.Memcached
             {
                 var connTask = _socket.ConnectAsync(_endpoint);
 
-                if (await Task.WhenAny(connTask, Task.Delay(_connectionTimeout)) == connTask)
+                if (await Task.WhenAny(connTask, Task.Delay(_connectionTimeout)).ConfigureAwait(false) == connTask)
                 {
-                    await connTask;
+                    await connTask.ConfigureAwait(false);
                 }
                 else
                 {
@@ -174,7 +174,7 @@ namespace Enyim.Caching.Memcached
             {
                 var ep = GetIPEndPoint(_endpoint);
                 if (_isSocketDisposed) return false;
-                await _socket.ConnectAsync(ep.Address, ep.Port);
+                await _socket.ConnectAsync(ep.Address, ep.Port).ConfigureAwait(false);
             }
 
             if (_socket != null)
@@ -200,7 +200,7 @@ namespace Enyim.Caching.Memcached
 #else
                         ((DnsEndPoint)_endpoint).Host
 #endif
-                        );
+                        ).ConfigureAwait(false);
                 }
                 else
                 {
@@ -253,8 +253,6 @@ namespace Enyim.Caching.Memcached
 
         public async Task ResetAsync()
         {
-            // await _inputStream.FlushAsync();
-
             int available = _socket.Available;
 
             if (available > 0)
@@ -268,7 +266,7 @@ namespace Enyim.Caching.Memcached
 
                 byte[] data = new byte[available];
 
-                await ReadAsync(data, 0, available);
+                await ReadAsync(data, 0, available).ConfigureAwait(false);
             }
 
             if (_logger.IsEnabled(LogLevel.Debug))
@@ -428,8 +426,8 @@ namespace Enyim.Caching.Memcached
                 try
                 {
                     int currentRead = (_useSslStream
-                        ? await _sslStream.ReadAsync(buffer, offset, shouldRead)
-                        : await _inputStream.ReadAsync(buffer, offset, shouldRead));
+                        ? await _sslStream.ReadAsync(buffer, offset, shouldRead).ConfigureAwait(false)
+                        : await _inputStream.ReadAsync(buffer, offset, shouldRead).ConfigureAwait(false));
                     if (currentRead == count)
                         break;
                     if (currentRead < 1)
@@ -578,14 +576,14 @@ namespace Enyim.Caching.Memcached
                 {
                     foreach (var buf in buffers)
                     {
-                        await _sslStream.WriteAsync(buf.Array, 0, buf.Count);
+                        await _sslStream.WriteAsync(buf.Array, 0, buf.Count).ConfigureAwait(false);
                     }
 
-                    await _sslStream.FlushAsync();
+                    await _sslStream.FlushAsync().ConfigureAwait(false);
                 }
                 else
                 {
-                    var bytesTransferred = await _socket.SendAsync(buffers, SocketFlags.None);
+                    var bytesTransferred = await _socket.SendAsync(buffers, SocketFlags.None).ConfigureAwait(false);
                     if (bytesTransferred <= 0)
                     {
                         _isAlive = false;

--- a/src/Enyim.Caching/Memcached/Protocol/Binary/BinaryNode.cs
+++ b/src/Enyim.Caching/Memcached/Protocol/Binary/BinaryNode.cs
@@ -58,9 +58,9 @@ namespace Enyim.Caching.Memcached.Protocol.Binary
 
         protected internal override async Task<PooledSocket> CreateSocketAsync()
         {
-            var retval = await base.CreateSocketAsync();
+            var retval = await base.CreateSocketAsync().ConfigureAwait(false);
 
-            if (_authenticationProvider != null && !(await AuthAsync(retval)))
+            if (_authenticationProvider != null && !await AuthAsync(retval).ConfigureAwait(false))
             {
                 _logger.LogError("Authentication failed: " + EndPoint);
 
@@ -105,15 +105,15 @@ namespace Enyim.Caching.Memcached.Protocol.Binary
         {
             SaslStep currentStep = new SaslStart(_authenticationProvider);
 
-            await socket.WriteAsync(currentStep.GetBuffer());
+            await socket.WriteAsync(currentStep.GetBuffer()).ConfigureAwait(false);
 
-            while (!(await currentStep.ReadResponseAsync(socket)).Success)
+            while (!(await currentStep.ReadResponseAsync(socket).ConfigureAwait(false)).Success)
             {
                 // challenge-response authentication
                 if (currentStep.StatusCode == 0x21)
                 {
                     currentStep = new SaslContinue(_authenticationProvider, currentStep.Data);
-                    await socket.WriteAsync(currentStep.GetBuffer());
+                    await socket.WriteAsync(currentStep.GetBuffer()).ConfigureAwait(false);
                 }
                 else
                 {

--- a/src/Enyim.Caching/Memcached/Protocol/Binary/BinaryResponse.cs
+++ b/src/Enyim.Caching/Memcached/Protocol/Binary/BinaryResponse.cs
@@ -80,7 +80,7 @@ namespace Enyim.Caching.Memcached.Protocol.Binary
             if (!socket.IsAlive) return false;
 
             var header = new byte[HeaderLength];
-            await socket.ReadAsync(header, 0, header.Length);
+            await socket.ReadAsync(header, 0, header.Length).ConfigureAwait(false);
 
             int dataLength, extraLength;
 
@@ -89,7 +89,7 @@ namespace Enyim.Caching.Memcached.Protocol.Binary
             if (dataLength > 0)
             {
                 var data = new byte[dataLength];
-                await socket.ReadAsync(data, 0, dataLength);
+                await socket.ReadAsync(data, 0, dataLength).ConfigureAwait(false);
 
                 Extra = new ArraySegment<byte>(data, 0, extraLength);
                 Data = new ArraySegment<byte>(data, extraLength, data.Length - extraLength);

--- a/src/Enyim.Caching/Memcached/Protocol/Binary/BinarySingleItemOperation.cs
+++ b/src/Enyim.Caching/Memcached/Protocol/Binary/BinarySingleItemOperation.cs
@@ -47,7 +47,7 @@ namespace Enyim.Caching.Memcached.Protocol.Binary
         protected internal override async ValueTask<IOperationResult> ReadResponseAsync(PooledSocket socket)
         {
             var response = new BinaryResponse();
-            var retval = await response.ReadAsync(socket);
+            var retval = await response.ReadAsync(socket).ConfigureAwait(false);
 
             Cas = response.CAS;
             StatusCode = response.StatusCode;

--- a/src/Enyim.Caching/Memcached/Protocol/Binary/FlushOperation.cs
+++ b/src/Enyim.Caching/Memcached/Protocol/Binary/FlushOperation.cs
@@ -36,7 +36,7 @@ namespace Enyim.Caching.Memcached.Protocol.Binary
         protected internal override async ValueTask<IOperationResult> ReadResponseAsync(PooledSocket socket)
         {
             var response = new BinaryResponse();
-            var retval = await response.ReadAsync(socket);
+            var retval = await response.ReadAsync(socket).ConfigureAwait(false);
 
             StatusCode = StatusCode;
             var result = new BinaryOperationResult()

--- a/src/Enyim.Caching/Memcached/Protocol/Binary/MultiGetOperation.cs
+++ b/src/Enyim.Caching/Memcached/Protocol/Binary/MultiGetOperation.cs
@@ -78,7 +78,7 @@ namespace Enyim.Caching.Memcached.Protocol.Binary
 
         protected internal override async Task<bool> ReadResponseAsync(PooledSocket socket, Action<bool> next)
         {
-            var result = await ReadResponseAsync(socket);
+            var result = await ReadResponseAsync(socket).ConfigureAwait(false);
             next(result.Success);
             return result.Success;
         }
@@ -152,7 +152,7 @@ namespace Enyim.Caching.Memcached.Protocol.Binary
 
             var response = new BinaryResponse();
 
-            while (await response.ReadAsync(socket))
+            while (await response.ReadAsync(socket).ConfigureAwait(false))
             {
                 StatusCode = response.StatusCode;
 

--- a/src/Enyim.Caching/Memcached/Protocol/Binary/SaslStep.cs
+++ b/src/Enyim.Caching/Memcached/Protocol/Binary/SaslStep.cs
@@ -38,7 +38,7 @@ namespace Enyim.Caching.Memcached.Protocol.Binary
         {
             var response = new BinaryResponse();
 
-            var retval = await response.ReadAsync(socket);
+            var retval = await response.ReadAsync(socket).ConfigureAwait(false);
 
             StatusCode = response.StatusCode;
             Data = response.Data.Array;

--- a/src/Enyim.Caching/Memcached/Protocol/Binary/StatsOperation.cs
+++ b/src/Enyim.Caching/Memcached/Protocol/Binary/StatsOperation.cs
@@ -64,7 +64,7 @@ namespace Enyim.Caching.Memcached.Protocol.Binary
             var serverData = new Dictionary<string, string>();
             var retval = false;
 
-            while ((await response.ReadAsync(socket)) && response.KeyLength > 0)
+            while ((await response.ReadAsync(socket).ConfigureAwait(false)) && response.KeyLength > 0)
             {
                 retval = true;
 

--- a/src/Enyim.Caching/Memcached/Protocol/Operation.cs
+++ b/src/Enyim.Caching/Memcached/Protocol/Operation.cs
@@ -29,12 +29,12 @@ namespace Enyim.Caching.Memcached.Protocol
 
         async Task<IOperationResult> IOperation.ReadResponseAsync(PooledSocket socket)
         {
-            return await ReadResponseAsync(socket);
+            return await ReadResponseAsync(socket).ConfigureAwait(false);
         }
 
         async Task<bool> IOperation.ReadResponseAsync(PooledSocket socket, Action<bool> next)
         {
-            return await ReadResponseAsync(socket, next);
+            return await ReadResponseAsync(socket, next).ConfigureAwait(false);
         }
 
         int IOperation.StatusCode

--- a/src/Enyim.Caching/MemcachedClient.Results.cs
+++ b/src/Enyim.Caching/MemcachedClient.Results.cs
@@ -492,7 +492,7 @@ namespace Enyim.Caching
             if (node != null)
             {
                 var command = _pool.OperationFactory.Delete(hashedKey, 0);
-                var commandResult = await node.ExecuteAsync(command);
+                var commandResult = await node.ExecuteAsync(command).ConfigureAwait(false);
 
                 if (commandResult.Success)
                 {

--- a/src/Enyim.Caching/MemcachedClient.cs
+++ b/src/Enyim.Caching/MemcachedClient.cs
@@ -106,22 +106,22 @@ namespace Enyim.Caching
 
         public async Task<bool> AddAsync(string key, object value)
         {
-            return await StoreAsync(StoreMode.Add, key, value);
+            return await StoreAsync(StoreMode.Add, key, value).ConfigureAwait(false);
         }
 
         public async Task<bool> AddAsync(string key, object value, int cacheSeconds)
         {
-            return await StoreAsync(StoreMode.Add, key, value, TimeSpan.FromSeconds(cacheSeconds));
+            return await StoreAsync(StoreMode.Add, key, value, TimeSpan.FromSeconds(cacheSeconds)).ConfigureAwait(false);
         }
 
         public async Task<bool> AddAsync(string key, object value, uint cacheSeconds)
         {
-            return await StoreAsync(StoreMode.Add, key, value, TimeSpan.FromSeconds(cacheSeconds));
+            return await StoreAsync(StoreMode.Add, key, value, TimeSpan.FromSeconds(cacheSeconds)).ConfigureAwait(false);
         }
 
         public async Task<bool> AddAsync(string key, object value, TimeSpan timeSpan)
         {
-            return await StoreAsync(StoreMode.Add, key, value, timeSpan);
+            return await StoreAsync(StoreMode.Add, key, value, timeSpan).ConfigureAwait(false);
         }
 
         public bool Set(string key, object value, int cacheSeconds)
@@ -141,17 +141,17 @@ namespace Enyim.Caching
 
         public async Task<bool> SetAsync(string key, object value, int cacheSeconds)
         {
-            return await StoreAsync(StoreMode.Set, key, value, TimeSpan.FromSeconds(cacheSeconds));
+            return await StoreAsync(StoreMode.Set, key, value, TimeSpan.FromSeconds(cacheSeconds)).ConfigureAwait(false);
         }
 
         public async Task<bool> SetAsync(string key, object value, uint cacheSeconds)
         {
-            return await StoreAsync(StoreMode.Set, key, value, TimeSpan.FromSeconds(cacheSeconds));
+            return await StoreAsync(StoreMode.Set, key, value, TimeSpan.FromSeconds(cacheSeconds)).ConfigureAwait(false);
         }
 
         public async Task<bool> SetAsync(string key, object value, TimeSpan timeSpan)
         {
-            return await StoreAsync(StoreMode.Set, key, value, timeSpan);
+            return await StoreAsync(StoreMode.Set, key, value, timeSpan).ConfigureAwait(false);
         }
 
         public bool Replace(string key, object value, int cacheSeconds)
@@ -171,17 +171,17 @@ namespace Enyim.Caching
 
         public async Task<bool> ReplaceAsync(string key, object value, int cacheSeconds)
         {
-            return await StoreAsync(StoreMode.Replace, key, value, TimeSpan.FromSeconds(cacheSeconds));
+            return await StoreAsync(StoreMode.Replace, key, value, TimeSpan.FromSeconds(cacheSeconds)).ConfigureAwait(false);
         }
 
         public async Task<bool> ReplaceAsync(string key, object value, uint cacheSeconds)
         {
-            return await StoreAsync(StoreMode.Replace, key, value, TimeSpan.FromSeconds(cacheSeconds));
+            return await StoreAsync(StoreMode.Replace, key, value, TimeSpan.FromSeconds(cacheSeconds)).ConfigureAwait(false);
         }
 
         public async Task<bool> ReplaceAsync(string key, object value, TimeSpan timeSpan)
         {
-            return await StoreAsync(StoreMode.Replace, key, value, timeSpan);
+            return await StoreAsync(StoreMode.Replace, key, value, timeSpan).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -315,7 +315,7 @@ namespace Enyim.Caching
 
             try
             {
-                var commandResult = await node.ExecuteAsync(command);
+                var commandResult = await node.ExecuteAsync(command).ConfigureAwait(false);
                 return BuildGetCommandResult(result, command, commandResult);
             }
             catch (Exception ex)
@@ -342,7 +342,7 @@ namespace Enyim.Caching
 
             try
             {
-                var commandResult = await node.ExecuteAsync(command);
+                var commandResult = await node.ExecuteAsync(command).ConfigureAwait(false);
                 return BuildGetCommandResult<T>(result, command, commandResult);
             }
             catch (Exception ex)
@@ -357,18 +357,18 @@ namespace Enyim.Caching
 
         public async Task<T> GetValueAsync<T>(string key)
         {
-            var result = await GetAsync<T>(key);
+            var result = await GetAsync<T>(key).ConfigureAwait(false);
             return result.Success ? result.Value : default(T);
         }
 
         public async Task<T> GetValueOrCreateAsync<T>(string key, int cacheSeconds, Func<Task<T>> generator)
         {
-            var result = await GetAsync<T>(key);
+            var result = await GetAsync<T>(key).ConfigureAwait(false);
             if (result.Success)
             {
                 if (_logger.IsEnabled(LogLevel.Debug))
                 {
-                    _logger.LogDebug($"Cache is hint. Key is '{key}'.");
+                    _logger.LogDebug($"Cache is hit. Key is '{key}'.");
                 }
 
                 return result.Value;
@@ -379,12 +379,12 @@ namespace Enyim.Caching
                 _logger.LogDebug($"Cache is missed. Key is '{key}'.");
             }
 
-            var value = await generator?.Invoke();
+            var value = await (generator?.Invoke()).ConfigureAwait(false);
             if (value != null)
             {
                 try
                 {
-                    await AddAsync(key, value, cacheSeconds);
+                    await AddAsync(key, value, cacheSeconds).ConfigureAwait(false);
 
                     if (_logger.IsEnabled(LogLevel.Debug))
                     {
@@ -563,17 +563,17 @@ namespace Enyim.Caching
 
         public async Task<bool> StoreAsync(StoreMode mode, string key, object value)
         {
-            return (await PerformStoreAsync(mode, key, value, 0)).Success;
+            return (await PerformStoreAsync(mode, key, value, 0).ConfigureAwait(false)).Success;
         }
 
         public async Task<bool> StoreAsync(StoreMode mode, string key, object value, DateTime expiresAt)
         {
-            return (await PerformStoreAsync(mode, key, value, MemcachedClient.GetExpiration(null, expiresAt))).Success;
+            return (await PerformStoreAsync(mode, key, value, MemcachedClient.GetExpiration(null, expiresAt)).ConfigureAwait(false)).Success;
         }
 
         public async Task<bool> StoreAsync(StoreMode mode, string key, object value, TimeSpan validFor)
         {
-            return (await PerformStoreAsync(mode, key, value, MemcachedClient.GetExpiration(validFor, null))).Success;
+            return (await PerformStoreAsync(mode, key, value, MemcachedClient.GetExpiration(validFor, null)).ConfigureAwait(false)).Success;
         }
 
         /// <summary>
@@ -749,7 +749,7 @@ namespace Enyim.Caching
                 }
 
                 var command = _pool.OperationFactory.Store(mode, hashedKey, item, expires, cas);
-                var commandResult = await node.ExecuteAsync(command);
+                var commandResult = await node.ExecuteAsync(command).ConfigureAwait(false);
 
                 result.Cas = cas = command.CasValue;
                 result.StatusCode = statusCode = command.StatusCode;
@@ -958,12 +958,12 @@ namespace Enyim.Caching
         #region Touch
         public async Task<IOperationResult> TouchAsync(string key, DateTime expiresAt)
         {
-            return await PerformMutateAsync(MutationMode.Touch, key, 0, 0, GetExpiration(null, expiresAt));
+            return await PerformMutateAsync(MutationMode.Touch, key, 0, 0, GetExpiration(null, expiresAt)).ConfigureAwait(false);
         }
 
         public async Task<IOperationResult> TouchAsync(string key, TimeSpan validFor)
         {
-            return await PerformMutateAsync(MutationMode.Touch, key, 0, 0, GetExpiration(validFor, null));
+            return await PerformMutateAsync(MutationMode.Touch, key, 0, 0, GetExpiration(validFor, null)).ConfigureAwait(false);
         }
         #endregion
 
@@ -1025,7 +1025,7 @@ namespace Enyim.Caching
             if (node != null)
             {
                 var command = _pool.OperationFactory.Mutate(mode, hashedKey, defaultValue, delta, expires, cas);
-                var commandResult = await node.ExecuteAsync(command);
+                var commandResult = await node.ExecuteAsync(command).ConfigureAwait(false);
 
                 result.Cas = cas = command.CasValue;
                 result.StatusCode = command.StatusCode;
@@ -1163,7 +1163,7 @@ namespace Enyim.Caching
                 tasks.Add(node.ExecuteAsync(command));
             }
 
-            await Task.WhenAll(tasks);
+            await Task.WhenAll(tasks).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1214,7 +1214,7 @@ namespace Enyim.Caching
 
         public async Task<bool> RemoveAsync(string key)
         {
-            return (await ExecuteRemoveAsync(key)).Success;
+            return (await ExecuteRemoveAsync(key).ConfigureAwait(false)).Success;
         }
 
         public async Task<bool> RemoveMultiAsync(params string[] keys)
@@ -1228,11 +1228,11 @@ namespace Enyim.Caching
                     tasks[i] = ExecuteRemoveAsync(keys[i]);
                 }
 
-                await Task.WhenAll(tasks);
+                await Task.WhenAll(tasks).ConfigureAwait(false);
 
                 foreach (var task in tasks)
                 {
-                    if (!(await task).Success) return false;
+                    if (!(await task.ConfigureAwait(false)).Success) return false;
                 }
 
                 return true;
@@ -1253,7 +1253,7 @@ namespace Enyim.Caching
 
         public async Task<IDictionary<string, T>> GetAsync<T>(IEnumerable<string> keys)
         {
-            return await PerformMultiGetAsync<T>(keys, (mget, kvp) => _transcoder.Deserialize<T>(kvp.Value));
+            return await PerformMultiGetAsync<T>(keys, (mget, kvp) => _transcoder.Deserialize<T>(kvp.Value)).ConfigureAwait(false);
         }
 
         public IDictionary<string, CasResult<object>> GetWithCas(IEnumerable<string> keys)
@@ -1271,7 +1271,7 @@ namespace Enyim.Caching
             {
                 Result = _transcoder.Deserialize(kvp.Value),
                 Cas = mget.Cas[kvp.Key]
-            });
+            }).ConfigureAwait(false);
         }
 
         protected virtual IDictionary<string, T> PerformMultiGet<T>(IEnumerable<string> keys, Func<IMultiGetOperation, KeyValuePair<string, CacheItem>, T> collector)
@@ -1358,7 +1358,7 @@ namespace Enyim.Caching
                 var mget = _pool.OperationFactory.MultiGet(nodeKeys);
                 var task = Task.Run(async () =>
                 {
-                    if ((await node.ExecuteAsync(mget)).Success)
+                    if ((await node.ExecuteAsync(mget).ConfigureAwait(false)).Success)
                     {
                         foreach (var kvp in mget.Result)
                         {
@@ -1372,7 +1372,7 @@ namespace Enyim.Caching
                 tasks.Add(task);
             }
 
-            await Task.WhenAll(tasks);
+            await Task.WhenAll(tasks).ConfigureAwait(false);
 
             return retval;
         }

--- a/src/Enyim.Caching/NullMemcachedClient.cs
+++ b/src/Enyim.Caching/NullMemcachedClient.cs
@@ -109,17 +109,17 @@ namespace Enyim.Caching
             return Task.FromResult(result);
         }
 
-        public async Task<IGetOperationResult<T>> GetAsync<T>(string key)
+        public Task<IGetOperationResult<T>> GetAsync<T>(string key)
         {
             var result = new DefaultGetOperationResultFactory<T>().Create();
             result.Success = false;
             result.Value = default(T);
-            return await Task.FromResult(result);
+            return Task.FromResult(result);
         }
 
-        public async Task<T> GetValueAsync<T>(string key)
+        public Task<T> GetValueAsync<T>(string key)
         {
-            return await Task.FromResult(default(T));
+            return Task.FromResult(default(T));
         }
 
         public IDictionary<string, CasResult<object>> GetWithCas(IEnumerable<string> keys)
@@ -127,9 +127,10 @@ namespace Enyim.Caching
             return new Dictionary<string, CasResult<object>>();
         }
 
-        public async Task<IDictionary<string, CasResult<object>>> GetWithCasAsync(IEnumerable<string> keys)
+        public Task<IDictionary<string, CasResult<object>>> GetWithCasAsync(IEnumerable<string> keys)
         {
-            return await Task.FromResult(new Dictionary<string, CasResult<object>>());
+            IDictionary<string, CasResult<object>> dictionary = new Dictionary<string, CasResult<object>>();
+            return Task.FromResult(dictionary);
         }
 
         public CasResult<object> GetWithCas(string key)
@@ -217,14 +218,14 @@ namespace Enyim.Caching
             return false;
         }
 
-        public async Task<bool> StoreAsync(StoreMode mode, string key, object value, TimeSpan validFor)
+        public Task<bool> StoreAsync(StoreMode mode, string key, object value, TimeSpan validFor)
         {
-            return await Task.FromResult(false);
+            return Task.FromResult(false);
         }
 
-        public async Task<bool> StoreAsync(StoreMode mode, string key, object value, DateTime expiresAt)
+        public Task<bool> StoreAsync(StoreMode mode, string key, object value, DateTime expiresAt)
         {
-            return await Task.FromResult(false);
+            return Task.FromResult(false);
         }
 
         public bool Store(StoreMode mode, string key, object value, DateTime expiresAt)


### PR DESCRIPTION
Using the library as is causes .NET Framework MVC sites to deadlock. 

As per the excellent Stephen Cleary (https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html) when targeting .NET framework; 

> In your "library" async methods, use `ConfigureAwait(false)` wherever possible.