### PR TITLE
Make PooledSocket.ReadAsync respect receive timeout setting

### DIFF
--- a/test/MemcachedTest/PooledSocketTest.cs
+++ b/test/MemcachedTest/PooledSocketTest.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Enyim.Caching.Memcached;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace MemcachedTest;
+
+public class PooledSocketTest
+{
+    [Fact]
+    public async Task ReadSync_ShouldTimeoutOrFail_WhenServerResponseIsSlow()
+    {
+        // Arrange
+        var logger = new NullLogger<PooledSocketTest>();
+        const int port = 12345;
+        var server = new SlowLorisServer();
+        using var cts = new CancellationTokenSource();
+        await server.StartAsync(port, cts.Token);
+        var endpoint = new IPEndPoint(IPAddress.Loopback, port);
+        var socket = new PooledSocket(
+            endpoint,
+            TimeSpan.FromSeconds(5),
+            TimeSpan.FromMilliseconds(50),
+            logger,
+            useSslStream: false,
+            useIPv6: false,
+            sslClientAuthOptions: null
+        );
+        await socket.ConnectAsync();
+        var buffer = new byte[server.Response.Length];
+        
+        // Act
+        var timer = Stopwatch.StartNew();
+        var ex = Record.Exception(() =>
+        {
+            socket.Read(buffer, 0, server.Response.Length);
+        });
+        timer.Stop();    
+        
+        // Assert
+        Assert.True(timer.Elapsed < TimeSpan.FromMilliseconds(500), "Read took too long");
+        Assert.NotNull(ex);
+        Assert.True(
+            ex is TimeoutException or IOException,
+            $"Expected TimeoutException or IOException, got {ex.GetType().Name}: {ex.Message}"
+        );
+        
+        await cts.CancelAsync();
+        server.Stop();
+    }
+    
+    [Fact]
+    public async Task ReadAsync_ShouldTimeoutOrFail_WhenServerResponseIsSlow()
+    {
+        // Arrange
+        var logger = new NullLogger<PooledSocket>();
+        const int port = 12345;
+        var server = new SlowLorisServer();
+        using var cts = new CancellationTokenSource();
+
+        await server.StartAsync(port, cts.Token);
+
+        var endpoint = new IPEndPoint(IPAddress.Loopback, port);
+        var socket = new PooledSocket(
+            endpoint,
+            TimeSpan.FromSeconds(5),
+            TimeSpan.FromMilliseconds(50),
+            logger,
+            useSslStream: false,
+            useIPv6: false,
+            sslClientAuthOptions: null
+        );
+        
+        await socket.ConnectAsync();
+        
+        var buffer = new byte[server.Response.Length];
+        
+        // Act
+        var timer = Stopwatch.StartNew();
+        var ex = await Record.ExceptionAsync(async () =>
+        {
+            await socket.ReadAsync(buffer, 0, server.Response.Length);
+        });
+        timer.Stop();
+
+        // Assert
+        Assert.True(timer.Elapsed < TimeSpan.FromMilliseconds(500), "ReadAsync took too long");
+        Assert.NotNull(ex);
+        Assert.True(
+            ex is TimeoutException or IOException,
+            $"Expected TimeoutException or IOException, got {ex.GetType().Name}: {ex.Message}"
+        );
+
+        // Cleanup
+        await cts.CancelAsync();
+        server.Stop();
+    }
+}
+
+public class SlowLorisServer
+{
+    private TcpListener _listener;
+    private CancellationToken _token;
+    public readonly byte[] Response = "Hello, I'm slow!"u8.ToArray();
+
+    public Task StartAsync(int port, CancellationToken token)
+    {
+        _token = token;
+        _listener = new TcpListener(IPAddress.Loopback, port);
+        _listener.Start();
+
+        _ = Task.Run(async () =>
+        {
+            while (!token.IsCancellationRequested)
+            {
+                var client = await _listener.AcceptTcpClientAsync(token);
+                _ = Task.Run(() => HandleClientAsync(client), token);
+            }
+        }, token);
+        return Task.CompletedTask;
+    }
+
+    private async Task HandleClientAsync(TcpClient client)
+    {
+        await using var stream = client.GetStream();
+        for (var i = 0; i < Response.Length; i++)
+        {
+            await stream.WriteAsync(Response, i, 1, _token);
+            await Task.Delay(100, _token);
+        }
+        await stream.FlushAsync(_token);
+        client.Close();
+    }
+
+    public void Stop() => _listener.Stop();
+}
+


### PR DESCRIPTION
We have seen examples of our memcached clients not timing out for several minutes on reads and/or writes in our Kubernetes environment under certain conditions occurring after node rebalancing and subsequent mecached pod rescheduling. This was despite us setting a very short (10ms) receive timeout in the client configuration.

After some digging, we realized that `Socket.ReceiveTimeout` only affects blocking receive calls. This is well-documented in the [Socket.ReceiveTimeout docs](https://learn.microsoft.com/en-us/dotnet/api/System.Net.Sockets.Socket.ReceiveTimeout?view=net-9.0#remarks), as well as the documentation for the underlying [`setsockopt` documentation](https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-setsockopt) (emphasis mine):
> SO_RCVTIMEO | DWORD | Sets the timeout, in milliseconds, for **blocking** receive calls.

This PR wraps calls to `NetworkStream.ReadAsync` in `PooledSocket` in a `Task.WhenAny(readTask, timeoutTask)`, a pattern already in use several other places in this codebase for other asynchronous socket operations. I also added tests to verify that the receive timeout setting is respected in both blocking and non-blocking `PooledSocket` reads.

