### PR TITLE
dont lose precision on cas operations

### DIFF
--- a/src/Enyim.Caching/Memcached/Protocol/Text/TextOperationFactory.cs
+++ b/src/Enyim.Caching/Memcached/Protocol/Text/TextOperationFactory.cs
@@ -20,7 +20,7 @@ namespace Enyim.Caching.Memcached.Protocol.Text
 			if (cas == 0)
 				return new StoreOperation(mode, key, value, expires);
 
-			return new CasOperation(key, value, expires, (uint)cas);
+			return new CasOperation(key, value, expires, cas);
 		}
 
 		IDeleteOperation IOperationFactory.Delete(string key, ulong cas)


### PR DESCRIPTION
there seems to be a bug in the library, which causes a 32-bit truncation of cas values. once your memcached cas id exceeds 4,294,967,296, cas operations through this library fail.