### PR TITLE
fix: Observe abandoned tasks after WhenAny timeouts

### DIFF
--- a/src/Enyim.Caching/Memcached/MemcachedNode.cs
+++ b/src/Enyim.Caching/Memcached/MemcachedNode.cs
@@ -627,6 +627,7 @@ namespace Enyim.Caching.Memcached
                         }
                         else
                         {
+                            resetTask.Observe();
                             _semaphore.Release();
                             socket.IsAlive = false;
 
@@ -1041,6 +1042,7 @@ namespace Enyim.Caching.Memcached
                     var writeSocketTask = pooledSocket.WriteAsync(b);
                     if (await Task.WhenAny(writeSocketTask, Task.Delay(_config.ConnectionTimeout)).ConfigureAwait(false) != writeSocketTask)
                     {
+                        writeSocketTask.Observe();
                         result.Fail("Timeout to pooledSocket.WriteAsync");
                         return result;
                     }
@@ -1056,6 +1058,7 @@ namespace Enyim.Caching.Memcached
                     var readResponseTask = op.ReadResponseAsync(pooledSocket);
                     if (await Task.WhenAny(readResponseTask, Task.Delay(_config.ConnectionTimeout)).ConfigureAwait(false) != readResponseTask)
                     {
+                        readResponseTask.Observe();
                         result.Fail($"Timeout to ReadResponseAsync(pooledSocket) for {op}");
                         return result;
                     }

--- a/src/Enyim.Caching/Memcached/PooledSocket.cs
+++ b/src/Enyim.Caching/Memcached/PooledSocket.cs
@@ -164,6 +164,7 @@ namespace Enyim.Caching.Memcached
                 }
                 else
                 {
+                    connTask.Observe();
                     if (_socket != null)
                     {
                         DisposeSocket();
@@ -446,6 +447,7 @@ namespace Enyim.Caching.Memcached
                     }
                     else
                     {
+                        readTask.Observe();
                         throw new TimeoutException($"Timeout to read from {_endpoint}.");
                     }
                 }

--- a/src/Enyim.Caching/Memcached/TaskObservers.cs
+++ b/src/Enyim.Caching/Memcached/TaskObservers.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Enyim.Caching.Memcached;
+
+internal static class TaskObservers
+{
+    public static void Observe(this Task task)
+    {
+        if (task.IsCompleted)
+        {
+            _ = task.Exception; // touch to observe if it already faulted
+            return;
+        }
+
+        task.ContinueWith(
+            static t => { _ = t.Exception; },
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+}


### PR DESCRIPTION
Prevents the finalizer from throwing an UnobservedTaskException during GC by explicitly observing the abandoned task in case it faults, which can occur if the socket is disposed of