### PR TITLE
chore: update MessagePack to get security fixes

### DIFF
--- a/src/Enyim.Caching/Enyim.Caching.csproj
+++ b/src/Enyim.Caching/Enyim.Caching.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="3.1.4" />
+    <PackageReference Include="MessagePack" Version="3.1.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In version 3.1.7 of MessagePack, many security issues were fixed: https://github.com/MessagePack-CSharp/MessagePack-CSharp/pull/2274

dotnet restore warns about them when building Enyim.Caching:
```
[nix-shell:~/clones/EnyimMemcachedCore]$ dotnet restore -p:WarningLevel=0
  Determining projects to restore...
.../EnyimMemcachedCore/src/Enyim.Caching/Enyim.Caching.csproj : warning NU1902: Package 'MessagePack' 3.1.4 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-2f33-pr97-265q
.../EnyimMemcachedCore/src/Enyim.Caching/Enyim.Caching.csproj : warning NU1902: Package 'MessagePack' 3.1.4 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-2x83-8g95-xh59
.../EnyimMemcachedCore/src/Enyim.Caching/Enyim.Caching.csproj : warning NU1903: Package 'MessagePack' 3.1.4 has a known high severity vulnerability, https://github.com/advisories/GHSA-382j-8mxh-c7x2
.../EnyimMemcachedCore/src/Enyim.Caching/Enyim.Caching.csproj : warning NU1902: Package 'MessagePack' 3.1.4 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-cj9g-3mj2-g8vv
.../EnyimMemcachedCore/src/Enyim.Caching/Enyim.Caching.csproj : warning NU1902: Package 'MessagePack' 3.1.4 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-cxmj-83gh-fp49
.../EnyimMemcachedCore/src/Enyim.Caching/Enyim.Caching.csproj : warning NU1903: Package 'MessagePack' 3.1.4 has a known high severity vulnerability, https://github.com/advisories/GHSA-hv8m-jj95-wg3x
.../EnyimMemcachedCore/src/Enyim.Caching/Enyim.Caching.csproj : warning NU1902: Package 'MessagePack' 3.1.4 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-q2h6-ghwm-5qm8
.../EnyimMemcachedCore/src/Enyim.Caching/Enyim.Caching.csproj : warning NU1902: Package 'MessagePack' 3.1.4 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-qhmf-xw27-6rqr
.../EnyimMemcachedCore/src/Enyim.Caching/Enyim.Caching.csproj : warning NU1902: Package 'MessagePack' 3.1.4 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-v72x-2h86-7f8m
.../EnyimMemcachedCore/src/Enyim.Caching/Enyim.Caching.csproj : warning NU1903: Package 'MessagePack' 3.1.4 has a known high severity vulnerability, https://github.com/advisories/GHSA-vh6j-jc39-fggf
.../EnyimMemcachedCore/src/Enyim.Caching/Enyim.Caching.csproj : warning NU1902: Package 'MessagePack' 3.1.4 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-w567-gjr2-hm5j
.../EnyimMemcachedCore/src/Enyim.Caching/Enyim.Caching.csproj : warning NU1902: Package 'MessagePack' 3.1.4 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-wfr3-xj75-pfwh
  All projects are up-to-date for restore.
```